### PR TITLE
added check for circular dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,8 +90,14 @@ var flatten = function(json) {
                 if (item === 'dependencies') {
                     json.deps = {};
                     Object.keys(json[item]).forEach(function(name) {
-                        var j = flatten(json[item][name]);
-                        data[j.name + '@' + j.version] = j;
+                        var childDependency = json['dependencies'][name];
+                        var dependencyId = childDependency.name + '@' + childDependency.version;
+                        if (data[dependencyId]) { // already exists
+                            return;
+                        }
+                        data[dependencyId] = true; // placeholder to prevent circular dependency
+                        var j = flatten(childDependency);
+                        data[dependencyId] = j;
                         json.deps[name] = j;
                         delete j.deps;
                     });


### PR DESCRIPTION
On a larger project, I was finding that circular dependencies were causing a stack overflow.  

I noticed that the dependency.name and dependency.version were being cached, so I added the condition to check for its existence already before continuing the flatten() recursion.
