### PR TITLE
Adding license checks in the LICENSE file (and variations)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ http://yuilibrary.com/license/
 
 var UNKNOWN = 'UNKNOWN';
 var data = {};
+var fs = require('fs');
+var path = require('path');
 var read = require('read-installed');
 var treeify = require('treeify');
 var license = require('./license');
@@ -17,9 +19,8 @@ var flatten = function(json) {
 
     data[json.name + '@' + json.version] = moduleInfo;
 
-
     if (json.repository) {
-        if (typeof json.repository === 'object') {
+        if (typeof json.repository === 'object' && typeof json.repository.url === 'string') {
             moduleInfo.repository = json.repository.url.replace('git://github.com', 'https://github.com').replace('.git', '');
         }
     }
@@ -44,9 +45,21 @@ var flatten = function(json) {
         } else if (typeof licenseData === 'string') {
             moduleInfo.licenses = licenseData;
         }
-    } else if (json.readme){
-        moduleInfo.licenses = license(json.readme) || UNKNOWN;
+    } else if (license(json.readme)) {
+        moduleInfo.licenses = license(json.readme);
+    } else {
+        var files = fs.readdirSync(json.path);
+        files.forEach(function(filename) {
+            if (filename.indexOf('LICENSE') > -1) {
+                moduleInfo.licenses = license(fs.readFileSync(path.join(json.path, filename), {encoding: 'utf8'}));
+            }
+        });
+
+        if (moduleInfo.licenses == UNKNOWN) {
+             console.log(json.path);
+        }
     }
+
     if (json.dependencies) {
         Object.keys(json.dependencies).forEach(function(name) {
             var childDependency = json.dependencies[name],

--- a/lib/license.js
+++ b/lib/license.js
@@ -1,5 +1,25 @@
+var MIT_LICENSE = ["Permission is hereby granted, free of charge, to any person obtaining",
+"a copy of this software and associated documentation files (the",
+"'Software'), to deal in the Software without restriction, including",
+"without limitation the rights to use, copy, modify, merge, publish,",
+"distribute, sublicense, and/or sell copies of the Software, and to",
+"permit persons to whom the Software is furnished to do so, subject to",
+"the following conditions:",
+"",
+"The above copyright notice and this permission notice shall be",
+"included in all copies or substantial portions of the Software.",
+"",
+"THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,",
+"EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF",
+"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.",
+"IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY",
+"CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,",
+"TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE",
+"SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."].join('\n');
+
+
 module.exports = function(str) {
-    if (str.indexOf('MIT') > -1) {
+    if (str.indexOf('MIT') > -1 || str.indexOf(MIT_LICENSE) > -1) {
         return 'MIT*';
     } else if (str.indexOf('BSD') > -1) {
         return 'BSD*';


### PR DESCRIPTION
Some packages include a LICENSE file (or variations) instead of including the license in the README or the package.json.

In my case, cut the number of 'UNKNOWN's in half.
