### PR TITLE
allow brittish spelling: "licence"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,11 @@ var flatten = function(json) {
     } else if (license(json.readme)) {
         moduleInfo.licenses = license(json.readme);
     } else {
+        console.log(json.path)
         files = fs.readdirSync(json.path).filter(function(filename) {
-            return filename.indexOf('LICENSE') > -1;
+            
+            console.log(filename)
+            return /LICEN(C|S)E/i.test(filename)
         });
 
         files.forEach(function(filename) {


### PR DESCRIPTION
This will detect open source license when it's spelt with a "c" and also when it's in not capitalized.

which will solve detect this library, https://github.com/dominictarr/event-stream/pull/69#issuecomment-50410714 
and probably many others written by non-american english speakers.
