### PR TITLE
Colorize terminal output using chalk.

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -5,11 +5,13 @@ http://yuilibrary.com/license/
 */
 
 var nopt = require('nopt'),
+    chalk = require('chalk'),
     known = {
         json: require('path'),
         csv: require('path'),
         unknown: Boolean,
         version: Boolean,
+        color: Boolean,
         start: String,
         help: Boolean
     },
@@ -44,6 +46,9 @@ var clean = function(args) {
 var setDefaults = function(parsed) {
     if (parsed === undefined) {
         parsed = clean();
+    }
+    if (parsed.color === undefined) {
+        parsed.color = chalk.supportsColor;
     }
     parsed.start = parsed.start || process.cwd();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,14 +10,22 @@ var data = {};
 var fs = require('fs');
 var path = require('path');
 var read = require('read-installed');
+var chalk = require('chalk');
 var treeify = require('treeify');
 var license = require('./license');
 
-var flatten = function(json) {
-    var moduleInfo = {licenses: UNKNOWN},
-        licenseData, files;
+var flatten = function(json, colorize) {
+    var moduleInfo, licenseData, files, key;
 
-    data[json.name + '@' + json.version] = moduleInfo;
+    if (colorize) {
+      moduleInfo = {licenses: chalk.bold.red(UNKNOWN)};
+      key = chalk.bold.blue(json.name) + chalk.dim('@') + chalk.green(json.version);
+    } else {
+      moduleInfo = {licenses: UNKNOWN};
+      key = json.name + '@' + json.version;
+    }
+
+    data[key] = moduleInfo;
 
     if (json.repository) {
         if (typeof json.repository === 'object' && typeof json.repository.url === 'string') {
@@ -72,7 +80,7 @@ var flatten = function(json) {
             if (data[dependencyId]) { // already exists
                 return;
             }
-            flatten(childDependency);
+            flatten(childDependency, colorize);
         });
     }
 };
@@ -82,7 +90,7 @@ exports.init = function(options, callback) {
     console.log('scanning' , options.start);
 
     read(options.start, function(err, json) {
-        flatten(json);
+        flatten(json, options.color);
         var sorted = {};
         Object.keys(data).sort().forEach(function(item) {
             if (options.unknown) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "mkdirp": "^0.3.5",
     "treeify": "^1.0.1",
     "nopt": "^2.2.0",
-    "read-installed": "^1.0.0"
+    "read-installed": "^1.0.0",
+    "chalk": "~0.5.1"
   },
   "devDependencies": {
     "yui-lint": "~0.1.1",


### PR DESCRIPTION
A suggestion for a terminal color scheme for the output.  Each dependency is bold blue (a la `tree`), the version is green, and any unknown license types are bold red.

An option is added, `--color` and --no-color`.
