### PR TITLE
Added checking that the license file is a normal file, because otherwise...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ var license = require('./license');
 
 var flatten = function(json) {
     var moduleInfo = {licenses: UNKNOWN},
-        licenseData, files;
+        licenseData, files, licenseFile;
 
     data[json.name + '@' + json.version] = moduleInfo;
 
@@ -55,7 +55,11 @@ var flatten = function(json) {
         });
 
         files.forEach(function(filename) {
-            moduleInfo.licenses = license(fs.readFileSync(path.join(json.path, filename), {encoding: 'utf8'}));
+            licenseFile = path.join(json.path, filename);
+            // Checking that the file is in fact a normal file and not a directory for example.
+            if (fs.lstatSync(licenseFile).isFile()) {
+                moduleInfo.licenses = license(fs.readFileSync(licenseFile, {encoding: 'utf8'}));
+            }
         });
     }
 


### PR DESCRIPTION
... an appropriately named directory crashes the license-checker through EISDIR, illegal operation on a directory.
