### PR TITLE
Fixed issue where circular dependencies in dependency tree would cause infinite recursion in "flatten" function.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,13 @@ var flatten = function(options) {
       key = json.name + '@' + json.version;
     }
 
+    // If we have processed this key already, just return the data object.
+    // This was added so that we don't recurse forever if there was a circular
+    // dependency in the dependency tree.
+    if (data[key]) {
+        return data;
+    }
+
     data[key] = moduleInfo;
 
     if (json.repository) {


### PR DESCRIPTION
Fixed issue where circular dependencies in dependency tree would cause the flatten function to infinitely recurse. If the current key is found to be already in the data object (which means it was already processed), we stop processing that key and return the data object.

Resolves: https://github.com/davglass/license-checker/issues/22
