### PR TITLE
Add option to see the path of a dependency if unknown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ var flatten = function(options) {
         data = options.data,
         key = json.name + '@' + json.version,
         colorize = options.color,
+        unknown = options.unknown,
         licenseData, files = [], licenseFile;
 
     if (colorize) {
@@ -46,6 +47,10 @@ var flatten = function(options) {
         if (typeof json.url === 'object') {
             moduleInfo.url = json.url.web;
         }
+    }
+
+    if (unknown) {
+      moduleInfo.dependencyPath = json.path;
     }
 
     licenseData = json.license || json.licenses || undefined;
@@ -106,6 +111,7 @@ var flatten = function(options) {
                 deps: childDependency,
                 data: data,
                 color: colorize,
+                unknown: unknown,
                 filter: options.filter
             });
         });
@@ -120,6 +126,7 @@ exports.init = function(options, callback) {
                 deps: json,
                 data: {},
                 color: options.color,
+                unknown: options.unknown,
                 filter: options.filter
             }),
             colorize = options.color,


### PR DESCRIPTION
This is only used if you add the --unknown tag.
This is useful as unknown licenses might cause trouble for your software and you.

This will help you to see unknown licenses and have an easier time to grab those dependencies and fix the issue.


The next step is to add an option to only show unknown licenses.