### PR TITLE
Ensure bin/license-checker runs

### DIFF
--- a/bin/license-checker
+++ b/bin/license-checker
@@ -25,6 +25,8 @@ checker.init(args, function(json, err) {
     if (!!err) {
         console.log('Found error');
         console.log(err);
+    }
+
     if (args.json) {
         formattedOutput = JSON.stringify(json, null, 2);
     } else if (args.csv) {

--- a/tests/bin-test.js
+++ b/tests/bin-test.js
@@ -1,0 +1,25 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    path = require('path'),
+    spawn = require('child_process').spawn;
+
+var tests = {
+    bin: {
+        topic: function() {
+            var test = this;
+            spawn(
+              'node', [path.join(__dirname, '../bin/license-checker')], {
+                stdio: 'ignore'
+              }
+            ).on('exit', function(code) {
+              test.callback(code === 0);
+            });
+        },
+        'exits with code 0': function(code) {
+          assert.ok(code);
+        },
+    }
+};
+
+vows.describe('license-checker').addBatch(tests).export(module);
+


### PR DESCRIPTION
looks like the latest release is missing a `}`. this adds a test to ensure that `bin/license-checker` exits with code 0 and adds the `}` to make it pass.