### PR TITLE
Fix json, csv and markdown output for license-checker

### DIFF
--- a/bin/license-checker
+++ b/bin/license-checker
@@ -34,24 +34,16 @@ checker.init(args, function(json, err) {
     } else if (args.markdown){
         formattedOutput = checker.asMarkDown(json, args.customFormat);
     } else {
-        if (args.json) {
-            formattedOutput = JSON.stringify(json, null, 2);
-        } else if (args.csv) {
-            formattedOutput = checker.asCSV(json);
-        } else if (args.markdown){
-            formattedOutput = checker.asMarkDown(json);
-        } else {
-            formattedOutput = checker.asTree(json);
-        }
+        formattedOutput = checker.asTree(json);
+    }
 
-        if (args.out) {
-            var dir = path.dirname(args.out);
-            mkdirp.sync(dir);
-            //Remove the color tags
-            formattedOutput = chalk.stripColor(formattedOutput);
-            fs.writeFileSync(args.out, formattedOutput, 'utf8');
-        } else {
-            console.log(formattedOutput);
-        }
+    if (args.out) {
+        var dir = path.dirname(args.out);
+        mkdirp.sync(dir);
+        //Remove the color tags
+        formattedOutput = chalk.stripColor(formattedOutput);
+        fs.writeFileSync(args.out, formattedOutput, 'utf8');
+    } else {
+        console.log(formattedOutput);
     }
 });


### PR DESCRIPTION
The merge in commit 313a7edc3dbdf8d50e43ba8da89306d3c89326bc seems to have been done incorrectly, leading to the output code never to be reached if args.json, args.csv or args.markdown are set.
