### PR TITLE
better license detection using levenshtein distances

### DIFF
--- a/lib/license.js
+++ b/lib/license.js
@@ -8,15 +8,20 @@ var BSD = /BSD\b/;
 var ISC = /ISC\b/;
 var APACHE = /Apache\b/;
 var WTFPL = /WTFPL\b/;
+var allNewlines = /\r?\n/g;
 
 var spdx = require('spdx-license-list/spdx-full');
 var cmp = require('leven');
 
-var licenses = Object.keys(spdx).map(function(license) {
-    obj = spdx[license];
-    obj.name = license;
-    return obj;
-})
+var licenses = Object.keys(spdx).map(function(name) {
+    license = spdx[name];
+    if (!license.osiApproved) {
+        return false;
+    }
+
+    license.name = name;
+    return license;
+}).filter(Boolean)
 
 function bestMatch(str, filter) {
     var tests = licenses;
@@ -25,15 +30,14 @@ function bestMatch(str, filter) {
         tests = licenses.filter(function(a) {
             return a.name.toLowerCase().indexOf(filter) > -1;
         })
-        console.log('filter', tests.map(function(a) { return a.name }));
     }
 
     var results = tests.map(function(license) {
         if (license.license.length * 2 < str) {
             return [license.name, Infinity]
         }
-
-        return [license.name, cmp(str, license.license)]
+        var dist = cmp(str, license.license);
+        return [license.name, dist]
     })
 
     results.sort(function(a, b) {
@@ -50,10 +54,7 @@ module.exports = function(str) {
     }
 
     var filter = null;
-
-    if (str) {
-        str = str.replace('\n', '');
-    }
+    str = str.replace(allNewlines, '');
 
     // Attempt to setup a fast path to avoid extraneous compares
     if (typeof str === 'undefined' || !str) {
@@ -78,13 +79,11 @@ module.exports = function(str) {
         filter = 'WTFPL';
     } else if (APACHE.test(str)) {
         filter = 'Apache';
+    } else {
+        return null
     }
 
     var results = bestMatch(str, filter);
-
-    console.log('----------------------------');
-    console.log(results[0][0]);
-    console.log(str);
 
     return results[0][0];
 };

--- a/lib/license.js
+++ b/lib/license.js
@@ -85,5 +85,5 @@ module.exports = function(str) {
 
     var results = bestMatch(str, filter);
 
-    return results[0][0];
+    return results[0] && results[0][0] || null;
 };

--- a/lib/license.js
+++ b/lib/license.js
@@ -39,7 +39,10 @@ function bestMatch(str, filter, filteredLicenses) {
     }
 
     results = tests.map(function(license) {
-        if (license.license.length * 2 < str) {
+        // if the incoming license copy to test is < the length of
+        // the standard license copy, bail because we're going to
+        // get a bad result anyhow.
+        if (license.license.length * 3 < str.length) {
             return [license.key, Infinity];
         }
         var dist = cmp(str, license.license);

--- a/lib/license.js
+++ b/lib/license.js
@@ -40,10 +40,10 @@ function bestMatch(str, filter) {
 
     results = tests.map(function(license) {
         if (license.license.length * 2 < str) {
-            return [license.name, Infinity];
+            return [license.key, Infinity];
         }
         var dist = cmp(str, license.license);
-        return [license.name, dist];
+        return [license.key, dist];
     });
 
     results.sort(function(a, b) {

--- a/lib/license.js
+++ b/lib/license.js
@@ -28,8 +28,8 @@ var licenses = Object.keys(spdx).map(function(key) {
     };
 }).filter(Boolean);
 
-function bestMatch(str, filter) {
-    var tests = licenses, results;
+function bestMatch(str, filter, filteredLicenses) {
+    var tests = filteredLicenses || licenses, results;
 
     if (filter) {
         filter = filter.toLowerCase();
@@ -53,7 +53,9 @@ function bestMatch(str, filter) {
     return results;
 }
 
-module.exports = function(str) {
+detect.bestMatch = bestMatch;
+
+function detect(str) {
 
     if (!str || str.toLowerCase().indexOf('error:') > -1) {
         return null;
@@ -93,3 +95,5 @@ module.exports = function(str) {
 
     return results[0] && results[0][0] || null;
 };
+
+module.exports = detect;

--- a/lib/license.js
+++ b/lib/license.js
@@ -13,14 +13,19 @@ var allNewlines = /\r?\n/g;
 var spdx = require('spdx-license-list/spdx-full');
 var cmp = require('leven');
 
-var licenses = Object.keys(spdx).map(function(name) {
-    var license = spdx[name];
+var licenses = Object.keys(spdx).map(function(key) {
+    var license = spdx[key];
     if (!license.osiApproved) {
         return false;
     }
 
-    license.name = name;
-    return license;
+    license.key = key;
+    return {
+        key: key,
+        name: license.name,
+        url: license.url,
+        license: license.license
+    };
 }).filter(Boolean);
 
 function bestMatch(str, filter) {

--- a/lib/license.js
+++ b/lib/license.js
@@ -1,38 +1,90 @@
-var MIT_LICENSE = /ermission is hereby granted, free of charge, to any/;
-var BSD_LICENSE = /edistribution and use in source and binary forms, with or withou/;
-var WTFPL_LICENSE = /DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE/;
-var ISC_LICENSE = /The ISC License/;
+var MIT_LICENSE = /ermission is hereby granted, free of charge, to any/i;
+var BSD_LICENSE = /edistribution and use in source and binary forms, with or withou/i;
+var WTFPL_LICENSE = /DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE/i;
+var ISC_LICENSE = /The ISC License/i;
+var APACHE_LICENSE = /Apache License/i;
 var MIT = /MIT\b/;
 var BSD = /BSD\b/;
 var ISC = /ISC\b/;
-var APACHE = /Apache License\b/;
+var APACHE = /Apache\b/;
 var WTFPL = /WTFPL\b/;
 
+var spdx = require('spdx-license-list/spdx-full');
+var cmp = require('leven');
+
+var licenses = Object.keys(spdx).map(function(license) {
+    obj = spdx[license];
+    obj.name = license;
+    return obj;
+})
+
+function bestMatch(str, filter) {
+    var tests = licenses;
+    if (filter) {
+        filter = filter.toLowerCase();
+        tests = licenses.filter(function(a) {
+            return a.name.toLowerCase().indexOf(filter) > -1;
+        })
+        console.log('filter', tests.map(function(a) { return a.name }));
+    }
+
+    var results = tests.map(function(license) {
+        if (license.license.length * 2 < str) {
+            return [license.name, Infinity]
+        }
+
+        return [license.name, cmp(str, license.license)]
+    })
+
+    results.sort(function(a, b) {
+        return a[1] - b[1];
+    })
+
+    return results;
+}
 
 module.exports = function(str) {
+
+    if (!str || str.toLowerCase().indexOf('error:') > -1) {
+        return null;
+    }
+
+    var filter = null;
+
     if (str) {
         str = str.replace('\n', '');
     }
+
+    // Attempt to setup a fast path to avoid extraneous compares
     if (typeof str === 'undefined' || !str) {
-        return 'Undefined';
+        return null;
     } else if (ISC_LICENSE.test(str)) {
-        return 'ISC*';
+        filter = 'ISC';
     } else if (MIT_LICENSE.test(str)) {
-        return 'MIT*';
+        filter = 'MIT';
     } else if (BSD_LICENSE.test(str)) {
-        return 'BSD*';
+        filter = 'BSD';
     } else if (WTFPL_LICENSE.test(str)) {
-        return 'WTFPL*';
+        filter = 'WTFPL';
+    } else if (APACHE_LICENSE.test(str)) {
+        filter = 'Apache';
     } else if (ISC.test(str)) {
-        return 'ISC*';
+        filter = 'ISC';
     } else if (MIT.test(str)) {
-        return 'MIT*';
+        filter = 'MIT';
     } else if (BSD.test(str)) {
-        return 'BSD*';
+        filter = 'BSD';
     } else if (WTFPL.test(str)) {
-        return 'WTFPL*';
+        filter = 'WTFPL';
     } else if (APACHE.test(str)) {
-        return 'Apache*';
+        filter = 'Apache';
     }
-    return null;
+
+    var results = bestMatch(str, filter);
+
+    console.log('----------------------------');
+    console.log(results[0][0]);
+    console.log(str);
+
+    return results[0][0];
 };

--- a/lib/license.js
+++ b/lib/license.js
@@ -14,35 +14,36 @@ var spdx = require('spdx-license-list/spdx-full');
 var cmp = require('leven');
 
 var licenses = Object.keys(spdx).map(function(name) {
-    license = spdx[name];
+    var license = spdx[name];
     if (!license.osiApproved) {
         return false;
     }
 
     license.name = name;
     return license;
-}).filter(Boolean)
+}).filter(Boolean);
 
 function bestMatch(str, filter) {
-    var tests = licenses;
+    var tests = licenses, results;
+
     if (filter) {
         filter = filter.toLowerCase();
         tests = licenses.filter(function(a) {
             return a.name.toLowerCase().indexOf(filter) > -1;
-        })
+        });
     }
 
-    var results = tests.map(function(license) {
+    results = tests.map(function(license) {
         if (license.license.length * 2 < str) {
-            return [license.name, Infinity]
+            return [license.name, Infinity];
         }
         var dist = cmp(str, license.license);
-        return [license.name, dist]
-    })
+        return [license.name, dist];
+    });
 
     results.sort(function(a, b) {
         return a[1] - b[1];
-    })
+    });
 
     return results;
 }
@@ -53,7 +54,7 @@ module.exports = function(str) {
         return null;
     }
 
-    var filter = null;
+    var filter = null, results;
     str = str.replace(allNewlines, '');
 
     // Attempt to setup a fast path to avoid extraneous compares
@@ -80,10 +81,10 @@ module.exports = function(str) {
     } else if (APACHE.test(str)) {
         filter = 'Apache';
     } else {
-        return null
+        return null;
     }
 
-    var results = bestMatch(str, filter);
+    results = bestMatch(str, filter);
 
     return results[0] && results[0][0] || null;
 };

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   ],
   "dependencies": {
     "chalk": "~0.5.1",
+    "leven": "^2.0.0",
     "mkdirp": "^0.3.5",
     "nopt": "^2.2.0",
     "read-installed": "~3.1.3",
+    "spdx-license-list": "^2.1.0",
     "treeify": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This patchset attempts to convert license text into its spdx name equivalent by using `leven`

**note**: this may break readme license detection

I'm using `lib/license.js` directly and have to do quite a bit of leg work to get it to behave with readme / package.json.  The main downside to this approach is, it is quite difficult to setup a threshold where the levenshtein distance is "acceptable" and not a false match.
