### PR TITLE
Add debug for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ license-checker
 You should see something like this:
 
 ```
-scanning ./yui-lint
 ├─ cli@0.4.3
 │  ├─ repository: http://github.com/chriso/cli
 │  └─ licenses: MIT
@@ -92,6 +91,25 @@ checker.init({
         //The sorted json data
     }
 });
+```
+
+Debugging
+---------
+
+license-checker uses [debug](https://www.npmjs.com/package/debug) for internal logging. There’s two internal markers:
+
+* `license-checker:error` for errors
+* `license-checker:log` for non-errors
+
+Set the `DEBUG` environment variable to one of these to see debug output:
+
+```shell
+$ export DEBUG=license-checker*; license-checker
+scanning ./yui-lint
+├─ cli@0.4.3
+│  ├─ repository: http://github.com/chriso/cli
+│  └─ licenses: MIT
+# ...
 ```
 
 build status

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,13 @@ var read = require('read-installed');
 var chalk = require('chalk');
 var treeify = require('treeify');
 var license = require('./license');
+var debug = require('debug');
+
+// Set up debug logging
+// https://www.npmjs.com/package/debug#stderr-vs-stdout
+var debugError = debug('license-checker:error');
+var debugLog = debug('license-checker:log');
+debugLog.log = console.log.bind(console);
 
 var flatten = function(options) {
     var moduleInfo = { licenses: UNKNOWN },
@@ -141,7 +148,7 @@ var flatten = function(options) {
 };
 
 exports.init = function(options, callback) {
-    console.error('scanning' , options.start);
+    debugLog('scanning %s', options.start);
 
     if (options.customPath) {
         options.customFormat = this.parseJson(options.customPath);
@@ -206,6 +213,7 @@ exports.init = function(options, callback) {
 
         /*istanbul ignore next*/
         if (err) {
+            debugError(err);
             inputError = err;
         }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "chalk": "~0.5.1",
+    "debug": "^2.2.0",
     "mkdirp": "^0.3.5",
     "nopt": "^2.2.0",
     "read-installed": "~3.1.3",


### PR DESCRIPTION
@davglass mentioned moving to [debug](https://www.npmjs.com/package/debug) in #46:

> we should include the `debug` module and then have the flags determine what is shown.

Took a stab at this. It looks like some tests aren’t passing, but I’m guessing that was the case anyway. Have a look and let me know what you think!