### PR TITLE
supporting --production and --development flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ You should see something like this:
 Options
 -------
 
+* `--production` only show production dependencies.
+* `--development` only show development dependencies.
 * `--unknown` report guessed licenses as unknown licenses.
 * `--onlyunknown` only list packages with unknown or guessed licenses.
 * `--json` output in json format.

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -18,6 +18,33 @@ if (!args.color && (args.json || args.csv || args.out)) {
     args.color = false;
 }
 
+if (args.help) {
+    console.log('license-checker@' + require('../package.json').version);
+    var usage = [
+        '',
+        '   --production only show production dependencies.',
+        '   --development only show development dependencies.',
+        '   --unknown report guessed licenses as unknown licenses.',
+        '   --onlyunknown only list packages with unknown or guessed licenses.',
+        '   --json output in json format.',
+        '   --csv output in csv format.',
+        '   --out [filepath] write the data to a specific file.',
+        '   --customPath to add a custom Format file in JSON',
+        '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',
+        '',
+        '   --version The current version',
+        '   --help  The text you are reading right now :)',
+        ''
+    ];
+    console.log(usage.join('\n'), '\n');
+    process.exit(0);
+}
+
+if (args.version) {
+    console.log(require('../package.json').version);
+    process.exit(1);
+}
+
 checker.init(args, function(json, err) {
 
     var formattedOutput = '';

--- a/lib/args.js
+++ b/lib/args.js
@@ -7,6 +7,8 @@ http://yuilibrary.com/license/
 var nopt = require('nopt'),
     chalk = require('chalk'),
     known = {
+        production: Boolean,
+        development: Boolean,
         json: Boolean,
         csv: Boolean,
         markdown: Boolean,

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,10 @@ var flatten = function(options) {
         return data;
     }
 
+    if ((options.production && json.extraneous) || (options.development && !json.extraneous && !json.root)) {
+        return data;
+    }
+
     data[key] = moduleInfo;
 
     if (json.repository) {
@@ -140,7 +144,9 @@ var flatten = function(options) {
                 data: data,
                 color: colorize,
                 unknown: unknown,
-                customFormat: options.customFormat
+                customFormat: options.customFormat,
+                production: options.production,
+                development: options.development
             });
         });
     }
@@ -153,14 +159,24 @@ exports.init = function(options, callback) {
     if (options.customPath) {
         options.customFormat = this.parseJson(options.customPath);
     }
+    var opts = {
+        dev: true,
+        log: debugLog
+    };
 
-    read(options.start, { dev: true }, function(err, json) {
+    if (options.production || options.development) {
+        opts.dev = false;
+    }
+
+    read(options.start, opts, function(err, json) {
         var data = flatten({
                 deps: json,
                 data: {},
                 color: options.color,
                 unknown: options.unknown,
-                customFormat: options.customFormat
+                customFormat: options.customFormat,
+                production: options.production,
+                development: options.development
             }),
             colorize = options.color,
             sorted = {},

--- a/tests/test.js
+++ b/tests/test.js
@@ -137,7 +137,8 @@ var tests = {
             var self = this;
 
             checker.init({
-                start: path.join(__dirname, '../')
+                start: path.join(__dirname, '../'),
+                development: true
             }, function (sorted, err) {
                 self.callback(sorted, err);
             });
@@ -267,7 +268,8 @@ var tests = {
             var self = this;
 
             checker.init({
-                start: path.join(__dirname, '../')
+                start: path.join(__dirname, '../'),
+                production: true
             }, function (sorted) {
                 self.callback(null, sorted);
             });


### PR DESCRIPTION
This fixes #52 by adding `--production` and `--development` flags similar to the way that `npm` does it.