### PR TITLE
Added a relativeLicensePath option to display the license file relatively to the current path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Options
 * `--out [filepath]` write the data to a specific file.
 * `--customPath` to add a custom Format file in JSON
 * `--exclude [list]` exclude modules which licenses are in the comma-separated list from the output
+* `--relativeLicensePath` output the location of the license files as relative paths 
 
 Examples
 --------

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -31,6 +31,7 @@ if (args.help) {
         '   --out [filepath] write the data to a specific file.',
         '   --customPath to add a custom Format file in JSON',
         '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',
+        '   --relativeLicensePath output the location of the license files as relative paths',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',

--- a/lib/args.js
+++ b/lib/args.js
@@ -19,6 +19,7 @@ var nopt = require('nopt'),
         color: Boolean,
         start: String,
         help: Boolean,
+        relativeLicensePath: Boolean,
         exclude: String,
         customPath: require('path'),
         customFormat: { }
@@ -60,6 +61,7 @@ var setDefaults = function(parsed) {
         parsed.color = chalk.supportsColor;
     }
     parsed.start = parsed.start || process.cwd();
+    parsed.relativeLicensePath = !!parsed.relativeLicensePath;
 
     return parsed;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ var flatten = function(options) {
                 //Only re-check the license if we didn't get it from elsewhere
                 moduleInfo.licenses = license(fs.readFileSync(licenseFile, {encoding: 'utf8'}));
             }
-            moduleInfo.licenseFile = licenseFile;
+            moduleInfo.licenseFile = options.basePath ? path.relative(options.basePath, licenseFile) : licenseFile;
         }
     });
 
@@ -147,7 +147,8 @@ var flatten = function(options) {
                 unknown: unknown,
                 customFormat: options.customFormat,
                 production: options.production,
-                development: options.development
+                development: options.development,
+                basePath: options.basePath
             });
         });
     }
@@ -177,7 +178,8 @@ exports.init = function(options, callback) {
                 unknown: options.unknown,
                 customFormat: options.customFormat,
                 production: options.production,
-                development: options.development
+                development: options.development,
+                basePath: options.relativeLicensePath ? json.path : null
             }),
             colorize = options.color,
             sorted = {},

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "Cory Reed <creed@mrn.org>",
     "Damien Larmine <damien.larmine@gmail.com>",
     "Dav Glass <davglass@gmail.com>",
+    "Dick Wiggers <dickje@gmail.com>",
     "Elijah Insua <tmpvar@gmail.com>",
     "Glen Arrowsmith <glen.arrowsmith@gmail.com>",
     "Holger Knust <holger.knust@certusview.com>",

--- a/tests/test.js
+++ b/tests/test.js
@@ -249,7 +249,6 @@ var tests = {
         },
         'output the location of the license files as absolute paths': function (d) {
             Object.keys(d).map(function (key) {
-                d[key].name = key.substr(0, key.indexOf("@"));
                 return d[key];
             }).filter(function (dep) {
                 return dep.licenseFile !== undefined;
@@ -273,7 +272,6 @@ var tests = {
         },
         'output the location of the license files as relative paths': function (d) {
             Object.keys(d).map(function (key) {
-                d[key].name = key.substr(0, key.indexOf("@"));
                 return d[key];
             }).filter(function (dep) {
                 return dep.licenseFile !== undefined;

--- a/tests/test.js
+++ b/tests/test.js
@@ -237,6 +237,51 @@ var tests = {
             });
         }
     },
+    'should output the location of the license files as absolute paths': {
+        topic: function() {
+            var self = this;
+
+            checker.init({
+                start: path.join(__dirname, '../')
+            }, function (filtered) {
+                self.callback(null, filtered);
+            });
+        },
+        'output the location of the license files as absolute paths': function (d) {
+            Object.keys(d).map(function (key) {
+                d[key].name = key.substr(0, key.indexOf("@"));
+                return d[key];
+            }).filter(function (dep) {
+                return dep.licenseFile !== undefined;
+            }).forEach(function(dep) {
+                var expectedPath = path.join(__dirname, '../');
+                var actualPath = dep.licenseFile.substr(0, expectedPath.length);
+                assert.equal(actualPath, expectedPath);
+            });
+        }
+    },
+    'should output the location of the license files as relative paths when using relativeLicensePath': {
+        topic: function() {
+            var self = this;
+
+            checker.init({
+                start: path.join(__dirname, '../'),
+                relativeLicensePath: true
+            }, function (filtered) {
+                self.callback(null, filtered);
+            });
+        },
+        'output the location of the license files as relative paths': function (d) {
+            Object.keys(d).map(function (key) {
+                d[key].name = key.substr(0, key.indexOf("@"));
+                return d[key];
+            }).filter(function (dep) {
+                return dep.licenseFile !== undefined;
+            }).forEach(function(dep) {
+                assert.notEqual(dep.licenseFile.substr(0, 1), "/");
+            });
+        }
+    },
     'should only list UNKNOWN or guessed licenses successful': {
         topic: function () {
             var self = this;


### PR DESCRIPTION
* Added a relativeLicensePath option to display the license file relatively to the current path.
* Added tests to validate workings
* Updated README
* Added contributor :)

I've used license-checker to export all dependencies + license file locations to a single file, but the paths were absolute: `/Users/sgtdck/Workspace/license-checker/node_modules/yui-lint/LICENSE`. To include this single file in my repo (i.e. 'third party licenses') I had to s/find/replace them.

With the option `--relativeLicensePath` the paths are now displayed relatively to the eldest parent (i.e. dir where `license-checker` is executed.