### PR TITLE
Added ability to output individual license files

### DIFF
--- a/bin/license-checker
+++ b/bin/license-checker
@@ -65,7 +65,10 @@ checker.init(args, function(json, err) {
         formattedOutput = checker.asTree(json);
     }
 
-    if (args.out) {
+    if (args.files) {
+        checker.asFiles(json, args.files);        
+    }
+    else if (args.out) {
         var dir = path.dirname(args.out);
         mkdirp.sync(dir);
         //Remove the color tags

--- a/lib/args.js
+++ b/lib/args.js
@@ -22,7 +22,8 @@ var nopt = require('nopt'),
         relativeLicensePath: Boolean,
         exclude: String,
         customPath: require('path'),
-        customFormat: { }
+        customFormat: { },
+        files: require('path')
     },
     shorts = {
         "v" : ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var chalk = require('chalk');
 var treeify = require('treeify');
 var license = require('./license');
 var debug = require('debug');
+var mkdirp = require('mkdirp');
 
 // Set up debug logging
 // https://www.npmjs.com/package/debug#stderr-vs-stdout
@@ -343,5 +344,26 @@ exports.parseJson = function(jsonPath) {
         result = err;
     } finally {
       return result;
+    }
+};
+
+exports.asFiles = function(json, outDir) {
+    mkdirp.sync(outDir);
+    try {
+        Object.keys(json).forEach(function (moduleName) {
+            var licenseFile = json[moduleName].licenseFile;
+            if (licenseFile && fs.existsSync(licenseFile)) {
+                var fileContents = fs.readFileSync(licenseFile),
+                    outFileName = chalk.stripColor(moduleName).replace(/(\s+|@)/g, "") + "-LICENSE.txt",
+                    outPath = path.join(outDir, outFileName);
+                fs.writeFileSync(outPath, fileContents, "utf8");
+            }
+            else {
+                console.warn("no license file found for: " + moduleName);
+            }
+        });
+    }
+    catch(ex) {
+        console.log(ex);
     }
 };


### PR DESCRIPTION
I had a need to output each license as a file. 

Usage: `license-checker --files ./path-to-output-folder`

Unfortunately no unit tests included because this: https://github.com/stjohnjohnson/jenkins-mocha/issues/13

Thanks for the great library!