### PR TITLE
Fix incorrect example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var checker = require('license-checker');
 
 checker.init({
     start: '/path/to/start/looking'
-}, function(json, err) {
+}, function(err, json) {
     if (err) {
         //Handle error
     } else {


### PR DESCRIPTION
According to https://github.com/davglass/license-checker/blob/master/lib/index.js#L264 the first parameter passed to the `init` callback is the error and the second one is the actual return value. This was incorrectly specified in the readme and is addressed in this pull request.