### PR TITLE
feat: add licenseText only for customFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The available items are the following:
 - url
 - licenses
 - licenseFile
+- licenseText
 - licenseModified
 
 You can also give default values for each item.

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,7 +165,9 @@ var flatten = function(options) {
             if (!content) {
                 content = fs.readFileSync(moduleInfo.licenseFile, {encoding: 'utf8'});
             }
-            moduleInfo.licenseText = content.replace(/"/g, '\'').replace(/\r?\n|\r/g, " ").trim();
+            if (options.customFormat) {
+                moduleInfo.licenseText = content.replace(/"/g, '\'').replace(/\r?\n|\r/g, " ").trim();
+            }
         }
     });
 

--- a/tests/config/custom_format_correct.json
+++ b/tests/config/custom_format_correct.json
@@ -4,5 +4,6 @@
 	"description": "",
 	"licenses": "",
 	"licenseFile": "none",
+	"licenseText": "none",
 	"licenseModified": "no"
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -245,7 +245,6 @@ describe('main tests', function() {
                     var expectedPath = path.join(__dirname, '../');
                     var actualPath = dep.licenseFile.substr(0, expectedPath.length);
                     assert.equal(actualPath, expectedPath);
-                    assert.ok(dep.licenseText);
                 });
                 done();
             });
@@ -262,7 +261,6 @@ describe('main tests', function() {
                     return dep.licenseFile !== undefined;
                 }).forEach(function(dep) {
                     assert.notEqual(dep.licenseFile.substr(0, 1), "/");
-                    assert.ok(dep.licenseText);
                 });
                 done();
             });


### PR DESCRIPTION
I think that licenseText is useful only for some people. I add them only to custom format.