### PR TITLE
fix: allow escaped commas in exclude string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -232,7 +232,9 @@ exports.init = function(options, callback) {
             colorize = options.color,
             sorted = {},
             filtered = {},
-            exclude = options.exclude && options.exclude.replace(/^\s+|\s+$/g, '').split(/\s*,\s*/),
+            exclude = options.exclude && options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
+                return license.replace(/\\,/g, ',').replace(/^\s+|\s+$/g, '');
+            }),
             inputError = null;
 
         Object.keys(data).sort().forEach(function(item) {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test": "jenkins-mocha ./tests/*.js",
     "posttest": "istanbul check-coverage"
   },
-  "preferGlobal": "true",
+  "preferGlobal": true,
   "bugs": {
     "url": "http://github.com/davglass/license-checker/issues"
   },

--- a/tests/fixtures/package.json
+++ b/tests/fixtures/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "invalid-with-comma",
+  "version": "0.0.0",
+  "licenses": [
+    {
+      "type": "Apache License, Version 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  ]
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -130,6 +130,28 @@ describe('main tests', function() {
         });
     });
 
+    describe('should parse local with excludes containing commas', function() {
+        var output;
+        before(function (done) {
+            checker.init({
+                start: path.join(__dirname, './fixtures'),
+                exclude: "Apache License\\, Version 2.0"
+            }, function (err, filtered) {
+                output = filtered;
+                done();
+            });
+        });
+
+        it('should exclude a license with a comma from the list', function () {
+            var excluded = true;
+            Object.keys(output).forEach(function(item) {
+                if (output[item].licenses && output[item].licenses == "Apache License, Version 2.0")
+                    excluded = false;
+            });
+            assert.ok(excluded);
+        });
+    });
+
     describe('error handler', function() {
         it('should init without errors', function(done) {
             checker.init({


### PR DESCRIPTION
This fixes #70. I've had to include a reference to an invalid syntax somewhere, let me know if I should move the fixture somewhere else.
The new RegEx matches everything that is either not an escaped comma and everything that is an escaped comma, so we have an correct array.