### PR TITLE
src: the README is added as licenseFile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ var flatten = function(options) {
         files = dirFiles.filter(function(filename) {
             filename = filename.toUpperCase();
             var name = path.basename(filename).replace(path.extname(filename), '');
-            return name === 'LICENSE' || name === 'LICENCE' || name === 'COPYING';
+            return name === 'LICENSE' || name === 'LICENCE' || name === 'COPYING' || name === 'README';
         });
         noticeFiles = dirFiles.filter(function(filename) {
             filename = filename.toUpperCase();


### PR DESCRIPTION
This small change is only to have the README value added to the `licenseFile` property.

sample output:
```
 { 'sample_dependency@1.0.0': 
       { licenses: 'MIT*',
         licenseFile: '/full path here/sample_dependency/README' } }
```

In some cases we need to have the README associated to `licenseFile`