### PR TITLE
FEATURE: Recognise some custom licenses

### DIFF
--- a/lib/license.js
+++ b/lib/license.js
@@ -15,7 +15,8 @@ var WTFPL = /WTFPL\b/;
 // https://creativecommons.org/publicdomain/zero/1.0/
 var CC0_1_0 = /The\s+person\s+who\s+associated\s+a\s+work\s+with\s+this\s+deed\s+has\s+dedicated\s+the\s+work\s+to\s+the\s+public\s+domain\s+by\s+waiving\s+all\s+of\s+his\s+or\s+her\s+rights\s+to\s+the\s+work\s+worldwide\s+under\s+copyright\s+law,\s+including\s+all\s+related\s+and\s+neighboring\s+rights,\s+to\s+the\s+extent\s+allowed\s+by\s+law.\s+You\s+can\s+copy,\s+modify,\s+distribute\s+and\s+perform\s+the\s+work,\s+even\s+for\s+commercial\s+purposes,\s+all\s+without\s+asking\s+permission./i; // jshint ignore:line
 var PUBLIC_DOMAIN = /[Pp]ublic [Dd]omain/;
-var IS_URL = /^https?:\/\//;
+var IS_URL = /https?:\/\//;
+var IS_FILE_REFERENCE = /SEE LICENSE IN (.*)/i;
 
 
 module.exports = function(str) {
@@ -69,6 +70,11 @@ module.exports = function(str) {
         return 'Public Domain';
     } else if(IS_URL.test(str)) {
         return 'Custom: ' + str;
+    } else {
+        var match = IS_FILE_REFERENCE.exec(str);
+        if(match) {
+            return 'Custom: ' + match[1];
+        }
     }
     return null;
 };

--- a/lib/license.js
+++ b/lib/license.js
@@ -15,6 +15,7 @@ var WTFPL = /WTFPL\b/;
 // https://creativecommons.org/publicdomain/zero/1.0/
 var CC0_1_0 = /The\s+person\s+who\s+associated\s+a\s+work\s+with\s+this\s+deed\s+has\s+dedicated\s+the\s+work\s+to\s+the\s+public\s+domain\s+by\s+waiving\s+all\s+of\s+his\s+or\s+her\s+rights\s+to\s+the\s+work\s+worldwide\s+under\s+copyright\s+law,\s+including\s+all\s+related\s+and\s+neighboring\s+rights,\s+to\s+the\s+extent\s+allowed\s+by\s+law.\s+You\s+can\s+copy,\s+modify,\s+distribute\s+and\s+perform\s+the\s+work,\s+even\s+for\s+commercial\s+purposes,\s+all\s+without\s+asking\s+permission./i; // jshint ignore:line
 var PUBLIC_DOMAIN = /[Pp]ublic [Dd]omain/;
+var IS_URL = /^https?:\/\//;
 
 
 module.exports = function(str) {
@@ -66,6 +67,8 @@ module.exports = function(str) {
         return 'LGPL-'+version+'*';
     } else if(PUBLIC_DOMAIN.test(str)) {
         return 'Public Domain';
+    } else if(IS_URL.test(str)) {
+        return 'Custom: ' + str;
     }
     return null;
 };

--- a/lib/license.js
+++ b/lib/license.js
@@ -69,7 +69,7 @@ module.exports = function(str) {
     } else if(PUBLIC_DOMAIN.test(str)) {
         return 'Public Domain';
     } else {
-        var match = IS_URL.exec(str) || IS_FILE_REFERENCE.exec(str);
+        match = IS_URL.exec(str) || IS_FILE_REFERENCE.exec(str);
         if(match) {
             return 'Custom: ' + match[1];
         } else {

--- a/lib/license.js
+++ b/lib/license.js
@@ -15,7 +15,7 @@ var WTFPL = /WTFPL\b/;
 // https://creativecommons.org/publicdomain/zero/1.0/
 var CC0_1_0 = /The\s+person\s+who\s+associated\s+a\s+work\s+with\s+this\s+deed\s+has\s+dedicated\s+the\s+work\s+to\s+the\s+public\s+domain\s+by\s+waiving\s+all\s+of\s+his\s+or\s+her\s+rights\s+to\s+the\s+work\s+worldwide\s+under\s+copyright\s+law,\s+including\s+all\s+related\s+and\s+neighboring\s+rights,\s+to\s+the\s+extent\s+allowed\s+by\s+law.\s+You\s+can\s+copy,\s+modify,\s+distribute\s+and\s+perform\s+the\s+work,\s+even\s+for\s+commercial\s+purposes,\s+all\s+without\s+asking\s+permission./i; // jshint ignore:line
 var PUBLIC_DOMAIN = /[Pp]ublic [Dd]omain/;
-var IS_URL = /https?:\/\//;
+var IS_URL = /(https?:\/\/[-a-zA-Z0-9\/.]*)/;
 var IS_FILE_REFERENCE = /SEE LICENSE IN (.*)/i;
 
 
@@ -68,13 +68,12 @@ module.exports = function(str) {
         return 'LGPL-'+version+'*';
     } else if(PUBLIC_DOMAIN.test(str)) {
         return 'Public Domain';
-    } else if(IS_URL.test(str)) {
-        return 'Custom: ' + str;
     } else {
-        var match = IS_FILE_REFERENCE.exec(str);
+        var match = IS_URL.exec(str) || IS_FILE_REFERENCE.exec(str);
         if(match) {
             return 'Custom: ' + match[1];
+        } else {
+            return null;
         }
     }
-    return null;
 };

--- a/tests/fixtures/custom-license-file/package.json
+++ b/tests/fixtures/custom-license-file/package.json
@@ -1,5 +1,5 @@
 {
   "name": "custom-license",
   "version": "0.0.0",
-  "license": "http://example.com/dummy-license"
+  "license": "See License in MY-LICENSE.md"
 }

--- a/tests/fixtures/custom-license-url/package.json
+++ b/tests/fixtures/custom-license-url/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "custom-license",
+  "version": "0.0.0",
+  "license": "http://example.com/dummy-license"
+}

--- a/tests/fixtures/custom-license/package.json
+++ b/tests/fixtures/custom-license/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "custom-license",
+  "version": "0.0.0",
+  "license": "http://example.com/dummy-license"
+}

--- a/tests/license.js
+++ b/tests/license.js
@@ -95,6 +95,22 @@ describe('license parser', function() {
         assert.equal(data, 'Public Domain');
     });
 
+    it('License at URL check', function() {
+        var data = license('http://example.com/foo');
+        assert.equal(data, 'Custom: http://example.com/foo');
+        data = license('See license at http://example.com/foo');
+        assert.equal(data, 'Custom: http://example.com/foo');
+        data = license('https://example.com/foo');
+        assert.equal(data, 'Custom: https://example.com/foo');
+    });
+
+    it('License at file check', function() {
+        var data = license('See license in LICENSE.md');
+        assert.equal(data, 'Custom: LICENSE.md');
+        data = license('SEE LICENSE IN LICENSE.md');
+        assert.equal(data, 'Custom: LICENSE.md');
+    });
+
 
     it('Check for null', function() {
         var data = license('this is empty, hi');

--- a/tests/test.js
+++ b/tests/test.js
@@ -223,6 +223,27 @@ describe('main tests', function() {
         });
     });
 
+    describe('should treat URLs as custom licenses', function() {
+        var output;
+        before(function(done) {
+            checker.init({
+                start: path.join(__dirname, './fixtures/custom-license')
+            }, function(err, filtered) {
+                output = filtered;
+                done();
+            });
+        });
+
+        it('should recognise a custom license', function() {
+            var foundCustomLicense = false;
+            Object.keys(output).forEach(function(item) {
+                if (output[item].licenses && (output[item].licenses === "Custom: http://example.com/dummy-license"))
+                    foundCustomLicense = true;
+            });
+            assert.ok(foundCustomLicense);
+        });
+    });
+
     describe('error handler', function() {
         it('should init without errors', function(done) {
             checker.init({

--- a/tests/test.js
+++ b/tests/test.js
@@ -180,19 +180,13 @@ describe('main tests', function() {
     });
 
     describe('should parse local with Public Domain excludes', function() {
-        var output;
-        before(function(done) {
-            checker.init({
-                start: path.join(__dirname, '../fixtures/exclusions2'),
-                exclude: "Public Domain"
-            }, function(err, filtered) {
-                output = filtered;
-                done();
-            });
-        });
+        var result={};
+        before(parseAndExclude('./fixtures/excludePublicDomain',  "Public Domain", result));
+
 
         it('should exclude Public Domain', function() {
             var excluded = true;
+            var output = result.output;
             Object.keys(output).forEach(function(item) {
                 if (output[item].licenses && output[item].licenses === "Public Domain")
                     excluded = false;

--- a/tests/test.js
+++ b/tests/test.js
@@ -227,17 +227,38 @@ describe('main tests', function() {
         var output;
         before(function(done) {
             checker.init({
-                start: path.join(__dirname, './fixtures/custom-license')
+                start: path.join(__dirname, './fixtures/custom-license-url')
             }, function(err, filtered) {
                 output = filtered;
                 done();
             });
         });
 
-        it('should recognise a custom license', function() {
+        it('should recognise a custom license at a url', function() {
             var foundCustomLicense = false;
             Object.keys(output).forEach(function(item) {
                 if (output[item].licenses && (output[item].licenses === "Custom: http://example.com/dummy-license"))
+                    foundCustomLicense = true;
+            });
+            assert.ok(foundCustomLicense);
+        });
+    });
+
+    describe('should treat file references as custom licenses', function() {
+        var output;
+        before(function(done) {
+            checker.init({
+                start: path.join(__dirname, './fixtures/custom-license-file')
+            }, function(err, filtered) {
+                output = filtered;
+                done();
+            });
+        });
+
+        it('should recognise a custom license in a file', function() {
+            var foundCustomLicense = false;
+            Object.keys(output).forEach(function(item) {
+                if (output[item].licenses && (output[item].licenses === "Custom: MY-LICENSE.md"))
                     foundCustomLicense = true;
             });
             assert.ok(foundCustomLicense);


### PR DESCRIPTION
The npm package.json spec explains that you can include a string reference to a license that doesn't have an SPDX identifier associated with it. This PR handles some basic examples