### PR TITLE
Added --failOn [list] mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Options
 * `--customPath` to add a custom Format file in JSON
 * `--exclude [list]` exclude modules which licenses are in the comma-separated list from the output
 * `--relativeLicensePath` output the location of the license files as relative paths
+* `--summary` output a summary of the license usage',
+* `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the comma-separated list
 
 Exclusions
 ----------

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -34,6 +34,7 @@ if (args.help) {
         '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',
         '   --relativeLicensePath output the location of the license files as relative paths',
         '   --summary output a summary of the license usage',
+        '   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the comma-separated list',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',

--- a/lib/args.js
+++ b/lib/args.js
@@ -25,7 +25,8 @@ var nopt = require('nopt'),
         customPath: require('path'),
         customFormat: { },
         files: require('path'),
-        summary: Boolean
+        summary: Boolean,
+        failOn: String
     },
     shorts = {
         "v": ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,6 +257,21 @@ exports.init = function(options, callback) {
         opts.dev = false;
     }
 
+    var toCheckforFailOn = [];
+    if (options.failOn) {
+        if (options.failOn.indexOf(',') > -1) {
+            var temp = options.failOn.split(',');
+            temp.forEach(function(license) {
+                var replaced = license.replace(/ /g, '');
+                if (replaced.length > 0) {
+                    toCheckforFailOn.push(replaced);
+                }
+            });
+        } else {
+            toCheckforFailOn.push(options.failOn.replace(/ /g, ''));
+        }
+    }
+
     read(options.start, opts, function(err, json) {
         var data = flatten({
                 deps: json,
@@ -283,7 +298,13 @@ exports.init = function(options, callback) {
         };
 
         Object.keys(data).sort().forEach(function(item) {
-            if(data[item].private) {
+            if (toCheckforFailOn.length > 0) {
+                if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
+                    console.log('Found license defined by the --failOn flag: "' + data[item].licenses + '". Exiting.');
+                    process.exit(1);
+                }
+            }
+            if (data[item].private) {
                 data[item].licenses = colorizeString(UNLICENSED);
             }
             /*istanbul ignore next*/

--- a/tests/failOn-test.js
+++ b/tests/failOn-test.js
@@ -1,0 +1,26 @@
+var assert = require('assert'),
+    path = require('path'),
+    spawn = require('child_process').spawn;
+
+describe('bin/license-checker', function() {
+    this.timeout(8000);
+    it('should exit 1 if it finds a single license type (MIT) license due to --failOn MIT', function(done) {
+        spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT'], {
+            cwd: path.join(__dirname, '../'),
+            stdio: 'ignore'
+        }).on('exit', function(code) {
+            assert.equal(code, 1);
+            done();
+        });
+    });
+
+    it('should exit 1 if it finds forbidden licenses license due to --failOn MIT,ISC', function(done) {
+        spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT,ISC'], {
+            cwd: path.join(__dirname, '../'),
+            stdio: 'ignore'
+        }).on('exit', function(code) {
+            assert.equal(code, 1);
+            done();
+        });
+    });
+});

--- a/tests/test.js
+++ b/tests/test.js
@@ -195,6 +195,41 @@ describe('main tests', function() {
         });
     });
 
+    function parseAndFailOn(parsePath, licenses, result) {
+        return function(done) {
+            var exitCode = 0;
+            process.exit = function(code) {
+                exitCode = code;
+            };
+            checker.init({
+                start: path.join(__dirname, parsePath),
+                failOn: licenses
+            }, function(err, filtered) {
+                result.output = filtered;
+                result.exitCode = exitCode;
+                done();
+            });
+        };
+    }
+
+    describe('should exit on given list of failOn licenses', function() {
+        var result={};
+        before(parseAndFailOn('../', "MIT, ISC", result));
+
+        it('should exit on MIT and ISC licensed modules from results', function() {
+            assert.equal(result.exitCode, 1);
+        });
+    });
+
+    describe('should exit on single failOn license', function() {
+        var result={};
+        before(parseAndFailOn('../', "ISC", result));
+
+        it('should exit on MIT and ISC licensed modules from results', function() {
+            assert.equal(result.exitCode, 1);
+        });
+    });
+
     describe('should parse local and handle private modules', function() {
         var output;
         before(function(done) {


### PR DESCRIPTION
The `--failOn [list]` mode is added to be able to use `license-checker` in CI/CD pipelines, e.g. to define the license types that should not be allowed in the final product. 

For example, `license-checker --failOn MIT` should trigger the process to exit with code `1` if the project uses a module which is MIT licensed.