### PR TITLE
app - output now includes path to dependency.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,6 +110,10 @@ var flatten = function(options) {
         });
     }
 
+    if (json.path && typeof json.path === 'string') {
+        moduleInfo.path = json.path;
+    }
+
     licenseData = json.license || json.licenses || undefined;
     
     if (json.path && (!json.readme || json.readme.toLowerCase().indexOf('no readme data found') > -1)) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -408,6 +408,25 @@ describe('main tests', function() {
 
     });
 
+    describe('should output the module location', function() {
+
+        it('as absolute path', function(done) {
+            checker.init({
+                start: path.join(__dirname, '../')
+            }, function(err, output) {
+                Object.keys(output).map(function(key) {
+                    var expectedPath = path.join(__dirname, '../');
+                    var actualPath = output[key].path.substr(0, expectedPath.length);
+                    console.log(expectedPath);
+                    console.log(output[key].path);
+                    assert.equal(actualPath, expectedPath);
+                });
+                done();
+            });
+        });
+
+    });
+
     describe('should output the location of the license files', function() {
 
         it('as absolute paths', function(done) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -417,8 +417,6 @@ describe('main tests', function() {
                 Object.keys(output).map(function(key) {
                     var expectedPath = path.join(__dirname, '../');
                     var actualPath = output[key].path.substr(0, expectedPath.length);
-                    console.log(expectedPath);
-                    console.log(output[key].path);
                     assert.equal(actualPath, expectedPath);
                 });
                 done();


### PR DESCRIPTION
If a dependency of a dependency has a license we want to dig into, it would be nice to get the exact path of the dependency. Currently, this involves doing a search throughout `node_modules`.

Not all modules have a license file (which displays the location). This PR should resolve this use case for all modules so the path is always available to the user.

Sample output:
```
├─ yargs@3.10.0
│  ├─ licenses: MIT
│  ├─ repository: https://github.com/bcoe/yargs
│  ├─ publisher: Alex Ford
│  ├─ email: Alex.Ford@CodeTunnel.com
│  ├─ url: http://CodeTunnel.com
│  ├─ path: C:\my_module\node_modules\uglify-js\node_modules\yargs
│  └─ licenseFile: C:\my_module\node_modules\uglify-js\node_modules\yargs\LICENSE
```