### PR TITLE
Add depth license checking management

### DIFF
--- a/bin/license-checker
+++ b/bin/license-checker
@@ -24,6 +24,7 @@ if (args.help) {
         '',
         '   --production only show production dependencies.',
         '   --development only show development dependencies.',
+        '   --start [path of the initial json to look for]',
         '   --unknown report guessed licenses as unknown licenses.',
         '   --onlyunknown only list packages with unknown or guessed licenses.',
         '   --json output in json format.',
@@ -36,6 +37,7 @@ if (args.help) {
         '   --summary output a summary of the license usage',
         '   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the comma-separated list',
         '   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the comma-seperated list',
+        '   --depth look for dependencies infinitely (default), --no-depth in order to look for direct dependencies only',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',
@@ -53,6 +55,13 @@ if (args.version) {
 if (args.failOn && args.onlyAllow) {
     console.log('--failOn and --onlyAllow can not be used at the same time. Choose one or the other.');
     process.exit(1);
+}
+
+// Prepare args.depth for read-installed
+if (args.depth === undefined || args.depth) {
+    args.depth = Infinity;
+} else {
+    args.depth = 0;
 }
 
 checker.init(args, function(err, json) {

--- a/lib/args.js
+++ b/lib/args.js
@@ -27,7 +27,8 @@ var nopt = require('nopt'),
         files: require('path'),
         summary: Boolean,
         failOn: String,
-        onlyAllow: String
+        onlyAllow: String,
+        depth: Boolean
     },
     shorts = {
         "v": ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ var flatten = function(options) {
     }
 
     licenseData = json.license || json.licenses || undefined;
-    
+
     if (json.path && (!json.readme || json.readme.toLowerCase().indexOf('no readme data found') > -1)) {
         readmeFile = path.join(json.path, 'README.md');
         /*istanbul ignore if*/
@@ -254,7 +254,8 @@ exports.init = function(options, callback) {
     }
     var opts = {
         dev: true,
-        log: debugLog
+        log: debugLog,
+        depth: options.depth // Use of depth feature from read-installed package
     };
 
     if (options.production || options.development) {


### PR DESCRIPTION
Hi,

Nice to meet you. 

I'm in the process of license validation and your tool was the closest to what I was looking for. It only missed a `depth` option management.

Here it is. I leveraged the `depth` option of `read-installed` package. It is not perfect because sometimes a `npm install` may installed dependencies of your direct dependencies at level 0. Anyway, it still allows filtering of `node_modules`.

I also documented the `start` option. Which I would I love to name `path`.