### PR TITLE
updated license list parser logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,10 +273,10 @@ exports.init = function(options, callback) {
         pusher = toCheckforFailOn;
     }
     if (checker && pusher) {
-        checker.split(',').forEach(function(license) {
-            var replaced = license.replace(/ /g, '');
-            if (replaced.length > 0) {
-                pusher.push(replaced);
+        checker.split(';').forEach(function(license) {
+            var trimmed = license.trim();
+            if (trimmed.length > 0) {
+                pusher.push(trimmed);
             }
         });
     }

--- a/tests/failOn-test.js
+++ b/tests/failOn-test.js
@@ -14,7 +14,7 @@ describe('bin/license-checker', function() {
         });
     });
 
-    it('should exit 1 if it finds forbidden licenses license due to --failOn MIT,ISC', function(done) {
+    it('should exit 1 if it finds forbidden licenses license due to --failOn MIT;ISC', function(done) {
         spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT,ISC'], {
             cwd: path.join(__dirname, '../'),
             stdio: 'ignore'

--- a/tests/test.js
+++ b/tests/test.js
@@ -215,7 +215,7 @@ describe('main tests', function() {
 
     describe('should exit on given list of onlyAllow licenses', function() {
         var result={};
-        before(parseAndFailOn('onlyAllow', '../', "MIT, ISC", result));
+        before(parseAndFailOn('onlyAllow', '../', "MIT; ISC", result));
 
         it('should exit on non MIT and ISC licensed modules from results', function() {
             assert.equal(result.exitCode, 1);
@@ -231,18 +231,31 @@ describe('main tests', function() {
         });
     });
 
-    describe('should exit on single onlyAllow license', function() {
+    describe('should not exit on complete list', function() {
         var result={};
-        before(parseAndFailOn('onlyAllow', '../', "ISC,", result));
+        before(parseAndFailOn('onlyAllow', '../', "MIT;ISC;MIT;BSD-3-Clause;BSD;Apache-2.0;" +
+            "BSD-2-Clause;Apache*;BSD*;CC-BY-3.0;Unlicense;CC0-1.0;The MIT License;AFLv2.1,BSD;" +
+            "Public Domain;Custom: http://i.imgur.com/goJdO.png;WTFPL*;Apache License, Version 2.0;" +
+            "WTFPL;(MIT AND CC-BY-3.0);Custom: https://github.com/substack/node-browserify;" +
+            "BSD-3-Clause OR MIT;(WTFPL OR MIT)", result));
 
-        it('should exit on non ISC licensed modules from results', function() {
+        it('should not exist if list is complete', function() {
+            assert.equal(result.exitCode, 0);
+        });
+    });
+
+    describe('should exit on given list of failOn licenses', function() {
+        var result={};
+        before(parseAndFailOn('failOn', '../', "Apache License, Version 2.0", result));
+
+        it('should exit on Apache License, Version 2.0 licensed modules from results', function() {
             assert.equal(result.exitCode, 1);
         });
     });
 
     describe('should exit on given list of failOn licenses', function() {
         var result={};
-        before(parseAndFailOn('failOn', '../', "MIT, ISC", result));
+        before(parseAndFailOn('failOn', '../', "MIT; ISC", result));
 
         it('should exit on MIT and ISC licensed modules from results', function() {
             assert.equal(result.exitCode, 1);


### PR DESCRIPTION
Hello! 

Thank you for the handy tool. It has been very useful. I recently started using the only allow option for a project I am working on and ran into a couple of snags. I think I have the solutions for them so I wanted to offer them back to you if you want them. The two issues I ran into were if the licenses had spaces in the name (e.g. "Public Domain") or if the there was a comma (e.g. "Apache License, Version 2.0"). Handling spaces was a fairly straight forward fix. For the commas I changed the separator to a ';'. If that change makes you uncomfortable an option could be added that would allow the user to specify the separator.