### PR TITLE
Drop support for node 4, add support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-    - "4"
     - "6"
+    - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
     - "6"
     - "8"
+cache:
+    directories:
+        - "node_modules"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 NPM License Checker
 ===================
 
+[![Build Status](https://www.travis-ci.org/davglass/license-checker.svg?branch=master)](https://www.travis-ci.org/davglass/license-checker)
+
 *As of v17.0.0 the `failOn` and `onlyAllow` arguments take semicolons as delimeters instead of commas. Some license names contain
 commas and it messed with the parsing*
 
@@ -86,7 +88,7 @@ Exclusions
 ----------
 A list of licenses is the simplest way to describe what you want to exclude.
 
-You can use valid [SPDX identifiers](https://spdx.org/licenses/). 
+You can use valid [SPDX identifiers](https://spdx.org/licenses/).
 You can use valid SPDX expressions like `MIT OR X11`.
 You can use non-valid SPDX identifiers, like `Public Domain`, since `npm` does
 support some license strings that are not SPDX identifiers.


### PR DESCRIPTION
Node 4.x went into maintenance on 2017-04-01 and the maintenance end is scheduled on April 2018, which is in one month. https://en.wikipedia.org/wiki/Node.js#Releases