### PR TITLE
Fix the "--failOn MIT;ISC" end to end test

### DIFF
--- a/bin/license-checker
+++ b/bin/license-checker
@@ -53,6 +53,12 @@ if (args.version) {
 if (args.failOn && args.onlyAllow) {
     console.log('--failOn and --onlyAllow can not be used at the same time. Choose one or the other.');
     process.exit(1);
+} else {
+    var argValue = args.failOn || args.onlyAllow;
+    if (argValue && argValue.indexOf(',') >= 0) {
+        var argName = args.failOn ? 'failOn' : 'onlyAllow';
+        console.warn('Warning: As of v17 the --' + argName + ' argument takes semicolons as delimeters instead of commas (some license names can contain commas)');
+    }
 }
 
 checker.init(args, function(err, json) {

--- a/tests/failOn-test.js
+++ b/tests/failOn-test.js
@@ -23,4 +23,20 @@ describe('bin/license-checker', function() {
             done();
         });
     });
+
+    it('should give warning about commas if --failOn MIT,ISC is provided', function(done) {
+        var proc = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT,ISC'], {
+            cwd: path.join(__dirname, '../'),
+            stdio: 'pipe'
+        });
+        var stderr = '';
+        proc.stdout.on('data', function() { });
+        proc.stderr.on('data', function(data) {
+            stderr += data.toString();
+        });
+        proc.on('close', function() {
+            assert.equal(stderr.indexOf('--failOn argument takes semicolons as delimeters instead of commas') >= 0, true);
+            done();
+        });
+    });
 });

--- a/tests/failOn-test.js
+++ b/tests/failOn-test.js
@@ -15,7 +15,7 @@ describe('bin/license-checker', function() {
     });
 
     it('should exit 1 if it finds forbidden licenses license due to --failOn MIT;ISC', function(done) {
-        spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT,ISC'], {
+        spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT;ISC'], {
             cwd: path.join(__dirname, '../'),
             stdio: 'ignore'
         }).on('exit', function(code) {


### PR DESCRIPTION
I'm not quite sure why it is not failing on the Travis CI, but locally the test failed consistently for me. When I tried it manually, the behavior was correct, but I noticed the test doesn't do exactly what it says. I fixed the tests.

Then I had a thought it would be nice to give warning about the change from commas to semicolons, so I implemented a naive alert to users when they do use commas with the `--failOn` and `--onlyAllow` arguments. I tested this change as well.