### PR TITLE
Test and improve detecting license text files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var read = require('read-installed');
 var chalk = require('chalk');
 var treeify = require('treeify');
 var license = require('./license');
+var licenseFiles = require('./license-files');
 var debug = require('debug');
 var mkdirp = require('mkdirp');
 var spdxSatisfies = require('spdx-satisfies');
@@ -115,7 +116,7 @@ var flatten = function(options) {
     }
 
     licenseData = json.license || json.licenses || undefined;
-    
+
     if (json.path && (!json.readme || json.readme.toLowerCase().indexOf('no readme data found') > -1)) {
         readmeFile = path.join(json.path, 'README.md');
         /*istanbul ignore if*/
@@ -155,20 +156,7 @@ var flatten = function(options) {
     /*istanbul ignore else*/
     if (json.path && fs.existsSync(json.path)) {
         dirFiles = fs.readdirSync(json.path);
-
-        // Find and list license files in the precedence order
-        ['LICENSE', 'LICENCE', 'COPYING', 'README'].forEach(function(licenseFilename) {
-            var found = false;
-            dirFiles.forEach(function(filename) {
-                if (!found) {
-                    var basename = path.basename(filename, path.extname(filename)).toUpperCase();
-                    if (basename === licenseFilename) {
-                        files.push(filename);
-                        found = true;
-                    }
-                }
-            });
-        });
+        files = licenseFiles(dirFiles);
 
         noticeFiles = dirFiles.filter(function(filename) {
             filename = filename.toUpperCase();

--- a/lib/license-files.js
+++ b/lib/license-files.js
@@ -1,0 +1,20 @@
+var path = require('path');
+
+
+// Find and list license files in the precedence order
+module.exports = function(dirFiles) {
+    var files = [];
+    ['LICENSE', 'LICENCE', 'COPYING', 'README'].forEach(function(licenseFilename) {
+        var found = false;
+        dirFiles.forEach(function(filename) {
+            if (!found) {
+                var basename = path.basename(filename, path.extname(filename)).toUpperCase();
+                if (basename === licenseFilename) {
+                    files.push(filename);
+                    found = true;
+                }
+            }
+        });
+    });
+    return files;
+};

--- a/lib/license-files.js
+++ b/lib/license-files.js
@@ -1,15 +1,24 @@
 var path = require('path');
 
+var BASENAMES_PRECEDENCE = [
+    /^LICENSE$/,
+    /^LICENSE\-\w+$/, // e.g. LICENSE-MIT
+    /^LICENCE$/,
+    /^LICENCE\-\w+$/, // e.g. LICENCE-MIT
+    /^COPYING$/,
+    /^README$/,
+];
+
 
 // Find and list license files in the precedence order
 module.exports = function(dirFiles) {
     var files = [];
-    ['LICENSE', 'LICENCE', 'COPYING', 'README'].forEach(function(licenseFilename) {
+    BASENAMES_PRECEDENCE.forEach(function(basenamePattern) {
         var found = false;
         dirFiles.forEach(function(filename) {
             if (!found) {
                 var basename = path.basename(filename, path.extname(filename)).toUpperCase();
-                if (basename === licenseFilename) {
+                if (basenamePattern.test(basename)) {
                     files.push(filename);
                     found = true;
                 }

--- a/tests/license-files-test.js
+++ b/tests/license-files-test.js
@@ -62,4 +62,26 @@ describe('license files detector', function() {
             'LiCeNcE',
         ]);
     });
+
+    it('LICENSE-MIT gets matched', function() {
+        assert.deepEqual(licenseFiles([
+            'LICENSE',
+            '.gitignore',
+            'LICENSE-MIT',
+            'src',
+        ]), [
+            'LICENSE',
+            'LICENSE-MIT',
+        ]);
+    });
+
+    it('only the first LICENSE-* file gets matched', function() {
+        assert.deepEqual(licenseFiles([
+            'license-foobar.txt',
+            '.gitignore',
+            'LICENSE-MIT',
+        ]), [
+            'license-foobar.txt',
+        ]);
+    });
 });

--- a/tests/license-files-test.js
+++ b/tests/license-files-test.js
@@ -1,0 +1,65 @@
+var assert = require('assert'),
+    licenseFiles = require('../lib/license-files');
+
+describe('license files detector', function() {
+
+    it('should export a function', function() {
+        assert.equal(typeof licenseFiles, 'function');
+    });
+
+    it('no files', function() {
+        assert.deepEqual(licenseFiles([]), []);
+    });
+
+    it('no license files', function() {
+        assert.deepEqual(licenseFiles([
+            '.gitignore',
+            '.travis.yml',
+            'TODO',
+        ]), []);
+    });
+
+    it('one license candidate', function() {
+        assert.deepEqual(licenseFiles([
+            'LICENSE',
+            '.gitignore',
+            'src',
+        ]), ['LICENSE']);
+    });
+
+    it('multiple license candidates detected in the right order', function() {
+        assert.deepEqual(licenseFiles([
+            'COPYING',
+            '.gitignore',
+            'LICENCE',
+            'LICENSE',
+            'src',
+            'README',
+        ]), [
+            'LICENSE',
+            'LICENCE',
+            'COPYING',
+            'README',
+        ]);
+    });
+
+    it('extensions have no effect', function() {
+        assert.deepEqual(licenseFiles([
+            'LICENCE.txt',
+            '.gitignore',
+            'src',
+        ]), [
+            'LICENCE.txt',
+        ]);
+    });
+
+    it('lower/upper case has no effect', function() {
+        assert.deepEqual(licenseFiles([
+            'LiCeNcE',
+            '.gitignore',
+            'src',
+        ]), [
+            'LiCeNcE',
+        ]);
+    });
+});


### PR DESCRIPTION
- Isolates the license file detection into a separate function (and file)
- Adds unit tests for the detection, verifies some of the issues I filed are not relevant to the license checker
- Adds support for LICENSE-MIT and similar license file names