### PR TITLE
Include Copyright Message in Output

### DIFF
--- a/customFormatExample.json
+++ b/customFormatExample.json
@@ -3,6 +3,7 @@
 	"version": "",
 	"description": "",
 	"licenses": "",
+	"copyright": "",
 	"licenseFile": "none",
 	"licenseText": "none",
 	"licenseModified": "no"

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,17 +202,21 @@ var flatten = function(options) {
                     }
 
                     var linesWithCopyright = content
-                        .split('\n')
-                        .filter(function(value) {
-                            return value.startsWith('opyright', 1) &&       // include copyright statements
-                                !value.startsWith('opyright notice', 1);    // exclude lines from from license text
+                        .replace(/\r\n/g, '\n')
+                        .split('\n\n')
+                        .filter(function selectCopyRightStatements(value) {
+                            return value.startsWith('opyright', 1) &&         // include copyright statements
+                                !value.startsWith('opyright notice', 1) &&    // exclude lines from from license text
+                                !value.startsWith('opyright and related rights', 1);
                         })
-                        .filter(function(value, index, list) {
-                            return index === 0 || value !== list[0];        // remove identical duplicates
+                        .filter(function removeDuplicates(value, index, list) {
+                            return index === 0 || value !== list[0];
                         });
 
                     if(linesWithCopyright.length > 0) {
-                        moduleInfo.copyright = linesWithCopyright[0].trim();
+                        moduleInfo.copyright = linesWithCopyright[0]
+                            .replace(/\n/g, '. ')
+                            .trim();
                     }
                 
                     // Mark files with multiple copyright statements. This might be

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ var flatten = function(options) {
 
     // Include property in output unless custom format has set property to false.
     var include = function(property) {
-        return true; // (options.customFormat === undefined || options.customFormat[property] !== false);
+        return options.customFormat === undefined || options.customFormat[property] !== false;
     };
 
     if (include("repository") && json.repository) {
@@ -178,7 +178,7 @@ var flatten = function(options) {
             }
 
             if (index === 0) {
-                // Treat the file with the highest precedense as licenseFile
+                // Treat the file with the highest precedence as licenseFile
                 /*istanbul ignore else*/
                 if (include("licenseFile")) {
                     moduleInfo.licenseFile = options.basePath ? path.relative(options.basePath, licenseFile) : licenseFile;
@@ -196,30 +196,30 @@ var flatten = function(options) {
                     }
                 }
 
-                if (!content) {
-                    content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
-                }
+                if(include('copyright') && options.customFormat) {
+                    if (!content) {
+                        content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
+                    }
 
-                var linesWithCopyright = content
+                    var linesWithCopyright = content
                     .split('\n')
                     .filter(function(value) {
                         return value.startsWith('opyright', 1) &&       // include copyright statements
-                            !value.startsWith('opyright notice', 1);    // exclude lines from from license text.
+                            !value.startsWith('opyright notice', 1);    // exclude lines from from license text
                     })
                     .filter(function(value, index, list) {
                         return index === 0 || value !== list[0];        // remove identical duplicates
                     });
 
-                if(linesWithCopyright.length > 0) {
-                    moduleInfo.copyright = linesWithCopyright[0].trim();
-                }
-
-                // Mark files with multiple copyright
-                // statements. This might be an
-                // indicator to take a closer look in
-                // the LICENSE file.
-                if(linesWithCopyright.length > 1) {
-                    moduleInfo.copyright += '*';
+                    if(linesWithCopyright.length > 0) {
+                        moduleInfo.copyright = linesWithCopyright[0].trim();
+                    }
+                
+                    // Mark files with multiple copyright statements. This might be
+                    // an indicator to take a closer look at the LICENSE file.
+                    if(linesWithCopyright.length > 1) {
+                        moduleInfo.copyright += '*';
+                    }
                 }
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ var flatten = function(options) {
 
     // Include property in output unless custom format has set property to false.
     var include = function(property) {
-        return options.customFormat === undefined || options.customFormat[property] !== false;
+        return (options.customFormat === undefined || options.customFormat[property] !== false);
     };
 
     if (include("repository") && json.repository) {
@@ -202,14 +202,14 @@ var flatten = function(options) {
                     }
 
                     var linesWithCopyright = content
-                    .split('\n')
-                    .filter(function(value) {
-                        return value.startsWith('opyright', 1) &&       // include copyright statements
-                            !value.startsWith('opyright notice', 1);    // exclude lines from from license text
-                    })
-                    .filter(function(value, index, list) {
-                        return index === 0 || value !== list[0];        // remove identical duplicates
-                    });
+                        .split('\n')
+                        .filter(function(value) {
+                            return value.startsWith('opyright', 1) &&       // include copyright statements
+                                !value.startsWith('opyright notice', 1);    // exclude lines from from license text
+                        })
+                        .filter(function(value, index, list) {
+                            return index === 0 || value !== list[0];        // remove identical duplicates
+                        });
 
                     if(linesWithCopyright.length > 0) {
                         moduleInfo.copyright = linesWithCopyright[0].trim();

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ var flatten = function(options) {
 
     // Include property in output unless custom format has set property to false.
     var include = function(property) {
-        return (options.customFormat === undefined || options.customFormat[property] !== false);
+        return true; // (options.customFormat === undefined || options.customFormat[property] !== false);
     };
 
     if (include("repository") && json.repository) {
@@ -194,6 +194,31 @@ var flatten = function(options) {
                     } else {
                         moduleInfo.licenseText = content.replace(/"/g, '\'').replace(/\r?\n|\r/g, " ").trim();
                     }
+                }
+
+                if (!content) {
+                    content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
+                }
+
+                var linesWithCopyright = content.split('\n')
+                    .filter(function(value) {
+                        return value.startsWith('opyright', 1) &&       // include copyright statements
+                            !value.startsWith('opyright notice', 1);    // exclude lines from from license text.
+                    })
+                    .filter(function(value, index, list) {
+                        return index === 0 || value !== list[0];        // remove identical duplicates
+                    });
+
+                if(linesWithCopyright.length > 0) {
+                    moduleInfo.copyright = linesWithCopyright[0];
+                }
+
+                // Mark files with multiple copyright
+                // statements. This might be an
+                // indicator to take a closer look in
+                // the LICENSE file.
+                if(linesWithCopyright.length > 1) {
+                    moduleInfo.copyright += '*';
                 }
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,7 +200,8 @@ var flatten = function(options) {
                     content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                 }
 
-                var linesWithCopyright = content.split('\n')
+                var linesWithCopyright = content
+                    .split('\n')
                     .filter(function(value) {
                         return value.startsWith('opyright', 1) &&       // include copyright statements
                             !value.startsWith('opyright notice', 1);    // exclude lines from from license text.
@@ -210,7 +211,7 @@ var flatten = function(options) {
                     });
 
                 if(linesWithCopyright.length > 0) {
-                    moduleInfo.copyright = linesWithCopyright[0];
+                    moduleInfo.copyright = linesWithCopyright[0].trim();
                 }
 
                 // Mark files with multiple copyright

--- a/tests/test.js
+++ b/tests/test.js
@@ -502,6 +502,28 @@ describe('main tests', function() {
         });
     });
 
+    describe('handle copytight statement', function(){
+
+        it('should output copyright statements when configured in custom format', function(done) {
+            checker.init({
+                start: path.join(__dirname, '../'),
+                customFormat: {
+                    copyright: '', // specify custom format
+                    email: false,
+                    licenseFile: false,
+                    licenseText: false,
+                    publisher: false
+                }
+            }, function(err, output) {
+                assert(output.hasOwnProperty('abbrev@1.0.9'), 'Check if the expected package still exists.');
+                assert.equal(output['abbrev@1.0.9'].copyright, 'Copyright (c) Isaac Z. Schlueter and Contributors');
+                done();
+            });
+
+        });
+
+    });
+
     describe('should only list UNKNOWN or guessed licenses successful', function() {
         var output;
         before(function(done) {


### PR DESCRIPTION
Hi @davglass 

very happy to use the license-checker on Node projects. For a current project we need the **copyright statement** for some licenses. 

I started adding this to extend this package for our needs. If you are interested in this feature, We could work on this PR to get it into a "deliverable" stage.

Update: Just saw, this could address issue #154 
