### PR TITLE
Update mkdirp to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "chalk": "~0.5.1",
     "debug": "^2.2.0",
-    "mkdirp": "^0.3.5",
+    "mkdirp": "^0.5.1",
     "nopt": "^2.2.0",
     "read-installed": "~4.0.3",
     "semver": "^5.3.0",


### PR DESCRIPTION
Previous versions of `mkdirp` used `0777` as a number ([link here](https://github.com/substack/node-mkdirp/blob/master/index.js#L64)), which will cause an error when compiling with `rollup` - so any library based on this package won't build because of that.

This PR should fix that.

