### PR TITLE
Fix exclude not including custom licenses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -408,9 +408,7 @@ exports.init = function(options, callback) {
 
                             if (invalidSPDXLicenses.indexOf(license) >= 0) {
                                 licenseMatch = true;
-                            } else if(spdxCorrect(license) === null) {
-                                licenseMatch = true;
-                            } else if (spdxSatisfies(spdxCorrect(license), spdxExcluder)) {
+                            } else if (spdxCorrect(license) && spdxSatisfies(spdxCorrect(license), spdxExcluder)) {
                                 licenseMatch = true;
                             }
                         }

--- a/tests/test.js
+++ b/tests/test.js
@@ -195,6 +195,22 @@ describe('main tests', function() {
         });
     });
 
+    describe('should not exclude Custom if not specified in excludes', function() {
+        var result={};
+        before(parseAndExclude('./fixtures/custom-license-file',  "MIT", result));
+
+
+        it('should exclude Public Domain', function() {
+            var excluded = true;
+            var output = result.output;
+            Object.keys(output).forEach(function(item) {
+                if (output[item].licenses && output[item].licenses === "Custom: MY-LICENSE.md")
+                    excluded = false;
+            });
+            assert.ok(!excluded);
+        });
+    });
+
     function parseAndFailOn(key, parsePath, licenses, result) {
         return function(done) {
             var exitCode = 0;


### PR DESCRIPTION
This PR fixes that when `--exclude` is added the custom dependencies are also excluded.

Steps to reproduce:
```
git clone git@github.com:mjpearson/passport-wordpress.git
cd passport-wordpress
npm install
license-checker --exclude 'MIT'
```

The output should be the `pkginfo@0.2.3` with a custom license, instead the output is nothing:

![image](https://user-images.githubusercontent.com/29209947/41058729-ecb0f1ea-69a0-11e8-864c-a0e6549623bd.png)

After the fix, the output is the right one:
![image](https://user-images.githubusercontent.com/29209947/41058802-1c83c6fe-69a1-11e8-9d76-07bf2d2ad101.png)

