### PR TITLE
feat: allow restricting output to specified packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options
 * `--summary` output a summary of the license usage',
 * `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
 * `--onlyAllow [list]` fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list
+* `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
 
 Exclusions
 ----------
@@ -102,6 +103,7 @@ license-checker --csv --out /path/to/licenses.csv
 license-checker --unknown
 license-checker --customPath customFormatExample.json
 license-checker --exclude 'MIT, MIT OR X11, BSD, ISC'
+license-checker --packages 'react@16.3.0;react-dom@16.3.0;lodash@4.3.1'
 license-checker --onlyunknown
 ```
 

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -37,6 +37,7 @@ if (args.help) {
         '   --summary output a summary of the license usage',
         '   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list',
         '   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list',
+        '   --packages [list] restrict output to the packages (package@version) in the semicolon-seperated list',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',

--- a/lib/args.js
+++ b/lib/args.js
@@ -27,7 +27,8 @@ var nopt = require('nopt'),
         files: require('path'),
         summary: Boolean,
         failOn: String,
-        onlyAllow: String
+        onlyAllow: String,
+        packages: String
     },
     shorts = {
         "v": ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var licenseFiles = require('./license-files');
 var debug = require('debug');
 var mkdirp = require('mkdirp');
 var spdxSatisfies = require('spdx-satisfies');
-var spdxCorrect =require('spdx-correct');
+var spdxCorrect = require('spdx-correct');
 var stripColor = require('strip-ansi');
 
 // Set up debug logging
@@ -33,7 +33,11 @@ var flatten = function(options) {
         colorize = options.color,
         unknown = options.unknown,
         readmeFile,
-        licenseData, dirFiles, files = [], noticeFiles = [], licenseFile;
+        licenseData,
+        dirFiles,
+        files = [],
+        noticeFiles = [],
+        licenseFile;
 
     /*istanbul ignore next*/
     if (colorize) {
@@ -53,7 +57,10 @@ var flatten = function(options) {
         return data;
     }
 
-    if ((options.production && json.extraneous) || (options.development && !json.extraneous && !json.root)) {
+    if (
+        (options.production && json.extraneous) ||
+    (options.development && !json.extraneous && !json.root)
+    ) {
         return data;
     }
 
@@ -61,34 +68,52 @@ var flatten = function(options) {
 
     // Include property in output unless custom format has set property to false.
     var include = function(property) {
-        return (options.customFormat === undefined || options.customFormat[property] !== false);
+        return (
+            options.customFormat === undefined ||
+      options.customFormat[property] !== false
+        );
     };
 
-    if (include("repository") && json.repository) {
-        /*istanbul ignore else*/
-        if (typeof json.repository === 'object' && typeof json.repository.url === 'string') {
-            moduleInfo.repository = json.repository.url.replace('git+ssh://git@', 'git://');
-            moduleInfo.repository = moduleInfo.repository.replace('git+https://github.com', 'https://github.com');
-            moduleInfo.repository = moduleInfo.repository.replace('git://github.com', 'https://github.com');
-            moduleInfo.repository = moduleInfo.repository.replace('git@github.com:', 'https://github.com/');
+    if (include('repository') && json.repository) {
+    /*istanbul ignore else*/
+        if (
+            typeof json.repository === 'object' &&
+      typeof json.repository.url === 'string'
+        ) {
+            moduleInfo.repository = json.repository.url.replace(
+                'git+ssh://git@',
+                'git://'
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(
+                'git+https://github.com',
+                'https://github.com'
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(
+                'git://github.com',
+                'https://github.com'
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(
+                'git@github.com:',
+                'https://github.com/'
+            );
             moduleInfo.repository = moduleInfo.repository.replace(/\.git$/, '');
         }
     }
-    if (include("url") && json.url) {
-        /*istanbul ignore next*/
+    if (include('url') && json.url) {
+    /*istanbul ignore next*/
         if (typeof json.url === 'object') {
             moduleInfo.url = json.url.web;
         }
     }
     if (json.author && typeof json.author === 'object') {
-        /*istanbul ignore else - This should always be there*/
-        if (include("publisher") && json.author.name) {
+    /*istanbul ignore else - This should always be there*/
+        if (include('publisher') && json.author.name) {
             moduleInfo.publisher = json.author.name;
         }
-        if (include("email") && json.author.email) {
+        if (include('email') && json.author.email) {
             moduleInfo.email = json.author.email;
         }
-        if (include("url") && json.author.url) {
+        if (include('url') && json.author.url) {
             moduleInfo.url = json.author.url;
         }
     }
@@ -112,13 +137,17 @@ var flatten = function(options) {
         });
     }
 
-    if (include("path") && json.path && typeof json.path === 'string') {
+    if (include('path') && json.path && typeof json.path === 'string') {
         moduleInfo.path = json.path;
     }
 
     licenseData = json.license || json.licenses || undefined;
 
-    if (json.path && (!json.readme || json.readme.toLowerCase().indexOf('no readme data found') > -1)) {
+    if (
+        json.path &&
+    (!json.readme ||
+      json.readme.toLowerCase().indexOf('no readme data found') > -1)
+    ) {
         readmeFile = path.join(json.path, 'README.md');
         /*istanbul ignore if*/
         if (fs.existsSync(readmeFile)) {
@@ -127,9 +156,9 @@ var flatten = function(options) {
     }
 
     if (licenseData) {
-        /*istanbul ignore else*/
+    /*istanbul ignore else*/
         if (Array.isArray(licenseData) && licenseData.length > 0) {
-            moduleInfo.licenses = licenseData.map(function(license){
+            moduleInfo.licenses = licenseData.map(function(license) {
                 /*istanbul ignore else*/
                 if (typeof license === 'object') {
                     /*istanbul ignore next*/
@@ -138,7 +167,10 @@ var flatten = function(options) {
                     return license;
                 }
             });
-        } else if (typeof licenseData === 'object' && (licenseData.type || licenseData.name)) {
+        } else if (
+            typeof licenseData === 'object' &&
+      (licenseData.type || licenseData.name)
+        ) {
             moduleInfo.licenses = license(licenseData.type || licenseData.name);
         } else if (typeof licenseData === 'string') {
             moduleInfo.licenses = license(licenseData);
@@ -148,7 +180,7 @@ var flatten = function(options) {
     }
 
     if (Array.isArray(moduleInfo.licenses)) {
-        /*istanbul ignore else*/
+    /*istanbul ignore else*/
         if (moduleInfo.licenses.length === 1) {
             moduleInfo.licenses = moduleInfo.licenses[0];
         }
@@ -172,7 +204,11 @@ var flatten = function(options) {
         /*istanbul ignore else*/
         if (fs.lstatSync(licenseFile).isFile()) {
             var content;
-            if (!moduleInfo.licenses || moduleInfo.licenses.indexOf(UNKNOWN) > -1 || moduleInfo.licenses.indexOf('Custom:') === 0) {
+            if (
+                !moduleInfo.licenses ||
+        moduleInfo.licenses.indexOf(UNKNOWN) > -1 ||
+        moduleInfo.licenses.indexOf('Custom:') === 0
+            ) {
                 //Only re-check the license if we didn't get it from elsewhere
                 content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                 moduleInfo.licenses = license(content);
@@ -181,11 +217,13 @@ var flatten = function(options) {
             if (index === 0) {
                 // Treat the file with the highest precedence as licenseFile
                 /*istanbul ignore else*/
-                if (include("licenseFile")) {
-                    moduleInfo.licenseFile = options.basePath ? path.relative(options.basePath, licenseFile) : licenseFile;
+                if (include('licenseFile')) {
+                    moduleInfo.licenseFile = options.basePath
+                        ? path.relative(options.basePath, licenseFile)
+                        : licenseFile;
                 }
 
-                if (include("licenseText") && options.customFormat) {
+                if (include('licenseText') && options.customFormat) {
                     if (!content) {
                         content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                     }
@@ -193,11 +231,14 @@ var flatten = function(options) {
                     if (options._args && !options._args.csv) {
                         moduleInfo.licenseText = content.trim();
                     } else {
-                        moduleInfo.licenseText = content.replace(/"/g, '\'').replace(/\r?\n|\r/g, " ").trim();
+                        moduleInfo.licenseText = content
+                            .replace(/"/g, "'")
+                            .replace(/\r?\n|\r/g, ' ')
+                            .trim();
                     }
                 }
 
-                if(include('copyright') && options.customFormat) {
+                if (include('copyright') && options.customFormat) {
                     if (!content) {
                         content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                     }
@@ -206,23 +247,25 @@ var flatten = function(options) {
                         .replace(/\r\n/g, '\n')
                         .split('\n\n')
                         .filter(function selectCopyRightStatements(value) {
-                            return value.startsWith('opyright', 1) &&         // include copyright statements
-                                !value.startsWith('opyright notice', 1) &&    // exclude lines from from license text
-                                !value.startsWith('opyright and related rights', 1);
+                            return (
+                                value.startsWith('opyright', 1) && // include copyright statements
+                !value.startsWith('opyright notice', 1) && // exclude lines from from license text
+                !value.startsWith('opyright and related rights', 1)
+                            );
                         })
                         .filter(function removeDuplicates(value, index, list) {
                             return index === 0 || value !== list[0];
                         });
 
-                    if(linesWithCopyright.length > 0) {
+                    if (linesWithCopyright.length > 0) {
                         moduleInfo.copyright = linesWithCopyright[0]
                             .replace(/\n/g, '. ')
                             .trim();
                     }
-                
+
                     // Mark files with multiple copyright statements. This might be
                     // an indicator to take a closer look at the LICENSE file.
-                    if(linesWithCopyright.length > 1) {
+                    if (linesWithCopyright.length > 1) {
                         moduleInfo.copyright += '*';
                     }
                 }
@@ -234,7 +277,9 @@ var flatten = function(options) {
         var file = path.join(json.path, filename);
         /*istanbul ignore else*/
         if (fs.lstatSync(file).isFile()) {
-            moduleInfo.noticeFile = options.basePath ? path.relative(options.basePath, file) : file;
+            moduleInfo.noticeFile = options.basePath
+                ? path.relative(options.basePath, file)
+                : file;
         }
     });
 
@@ -243,7 +288,8 @@ var flatten = function(options) {
         Object.keys(json.dependencies).forEach(function(name) {
             var childDependency = json.dependencies[name],
                 dependencyId = childDependency.name + '@' + childDependency.version;
-            if (data[dependencyId]) { // already exists
+            if (data[dependencyId]) {
+                // already exists
                 return;
             }
             data = flatten({
@@ -255,7 +301,7 @@ var flatten = function(options) {
                 production: options.production,
                 development: options.development,
                 basePath: options.basePath,
-                _args: options._args
+                _args: options._args,
             });
         });
     }
@@ -273,7 +319,7 @@ exports.init = function(options, callback) {
     }
     var opts = {
         dev: true,
-        log: debugLog
+        log: debugLog,
     };
 
     if (options.production || options.development) {
@@ -311,14 +357,16 @@ exports.init = function(options, callback) {
                 production: options.production,
                 development: options.development,
                 basePath: options.relativeLicensePath ? json.path : null,
-                _args: options
+                _args: options,
             }),
             colorize = options.color,
             sorted = {},
             filtered = {},
-            exclude = options.exclude && options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
-                return license.replace(/\\,/g, ',').replace(/^\s+|\s+$/g, '');
-            }),
+            exclude =
+        options.exclude &&
+        options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
+            return license.replace(/\\,/g, ',').replace(/^\s+|\s+$/g, '');
+        }),
             inputError = null;
 
         var colorizeString = function(string) {
@@ -326,100 +374,140 @@ exports.init = function(options, callback) {
             return colorize ? chalk.bold.red(string) : string;
         };
 
-        Object.keys(data).sort().forEach(function(item) {
-            if (toCheckforFailOn.length > 0) {
-                if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
-                    console.error('Found license defined by the --failOn flag: "' + data[item].licenses + '". Exiting.');
-                    process.exit(1);
-                }
-            }
-            if (toCheckforOnlyAllow.length > 0) {
-                var good = false;
-                toCheckforOnlyAllow.forEach(function(k) {
-                    if (data[item].licenses.indexOf(k) === -1 && !good) {
-                        good = false;
-                    } else {
-                        good = true;
+        Object.keys(data)
+            .sort()
+            .forEach(function(item) {
+                if (toCheckforFailOn.length > 0) {
+                    if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
+                        console.error(
+                            'Found license defined by the --failOn flag: "' +
+                data[item].licenses +
+                '". Exiting.'
+                        );
+                        process.exit(1);
                     }
-                });
-                if (!good) {
-                    console.error('Found license NOT defined by the --onlyAllow flag: "' + data[item].licenses + '". Exiting.');
-                    process.exit(1);
                 }
-            }
-            if (data[item].private) {
-                data[item].licenses = colorizeString(UNLICENSED);
-            }
-            /*istanbul ignore next*/
-            if (!data[item].licenses) {
-                data[item].licenses = colorizeString(UNKNOWN);
-            }
-            if (options.unknown) {
+                if (toCheckforOnlyAllow.length > 0) {
+                    var good = false;
+                    toCheckforOnlyAllow.forEach(function(k) {
+                        if (data[item].licenses.indexOf(k) === -1 && !good) {
+                            good = false;
+                        } else {
+                            good = true;
+                        }
+                    });
+                    if (!good) {
+                        console.error(
+                            'Found license NOT defined by the --onlyAllow flag: "' +
+                data[item].licenses +
+                '". Exiting.'
+                        );
+                        process.exit(1);
+                    }
+                }
+                if (data[item].private) {
+                    data[item].licenses = colorizeString(UNLICENSED);
+                }
+                /*istanbul ignore next*/
+                if (!data[item].licenses) {
+                    data[item].licenses = colorizeString(UNKNOWN);
+                }
+                if (options.unknown) {
+                    /*istanbul ignore else*/
+                    if (data[item].licenses && data[item].licenses !== UNKNOWN) {
+                        if (data[item].licenses.indexOf('*') > -1) {
+                            /*istanbul ignore if*/
+                            data[item].licenses = colorizeString(UNKNOWN);
+                        }
+                    }
+                }
                 /*istanbul ignore else*/
-                if (data[item].licenses && data[item].licenses !== UNKNOWN) {
-                    if (data[item].licenses.indexOf('*') > -1) {
-                        /*istanbul ignore if*/
-                        data[item].licenses = colorizeString(UNKNOWN);
-                    }
-                }
-            }
-            /*istanbul ignore else*/
-            if (data[item]) {
-                if (options.onlyunknown) {
-                    if (data[item].licenses.indexOf('*') > -1 ||
-                        data[item].licenses.indexOf(UNKNOWN) > -1) {
+                if (data[item]) {
+                    if (options.onlyunknown) {
+                        if (
+                            data[item].licenses.indexOf('*') > -1 ||
+              data[item].licenses.indexOf(UNKNOWN) > -1
+                        ) {
+                            sorted[item] = data[item];
+                        }
+                    } else {
                         sorted[item] = data[item];
                     }
-                } else {
-                    sorted[item] = data[item];
                 }
-            }
-        });
+            });
         if (exclude) {
             var transformBSD = function(spdx) {
-                return spdx === 'BSD' ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)' : spdx;
+                return spdx === 'BSD'
+                    ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)'
+                    : spdx;
             };
-            var invert = function(fn) { return function(spdx) { return !fn(spdx);};};
-            var spdxIsValid = function(spdx) { return spdxCorrect(spdx) === spdx; };
+            var invert = function(fn) {
+                return function(spdx) {
+                    return !fn(spdx);
+                };
+            };
+            var spdxIsValid = function(spdx) {
+                return spdxCorrect(spdx) === spdx;
+            };
 
             var validSPDXLicenses = exclude.map(transformBSD).filter(spdxIsValid);
-            var invalidSPDXLicenses = exclude.map(transformBSD).filter(invert(spdxIsValid));
+            var invalidSPDXLicenses = exclude
+                .map(transformBSD)
+                .filter(invert(spdxIsValid));
             var spdxExcluder = '( ' + validSPDXLicenses.join(' OR ') + ' )';
 
             Object.keys(sorted).forEach(function(item) {
                 var licenses = sorted[item].licenses;
                 /*istanbul ignore if - just for protection*/
-                if(!licenses) {
+                if (!licenses) {
                     filtered[item] = sorted[item];
                 } else {
                     licenses = [].concat(licenses);
                     var licenseMatch = false;
                     licenses.forEach(function(license) {
                         /*istanbul ignore if - just for protection*/
-                        if (license.indexOf(UNKNOWN) >= 0) { // necessary due to colorization
+                        if (license.indexOf(UNKNOWN) >= 0) {
+                            // necessary due to colorization
                             filtered[item] = sorted[item];
                         } else {
-                            if(license.indexOf('*') >= 0) {
+                            if (license.indexOf('*') >= 0) {
                                 license = license.substring(0, license.length - 1);
                             }
-                            if(license === 'BSD') {
-                                license = '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)';
+                            if (license === 'BSD') {
+                                license =
+                  '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)';
                             }
 
                             if (invalidSPDXLicenses.indexOf(license) >= 0) {
                                 licenseMatch = true;
-                            } else if (spdxCorrect(license) && spdxSatisfies(spdxCorrect(license), spdxExcluder)) {
+                            } else if (
+                                spdxCorrect(license) &&
+                spdxSatisfies(spdxCorrect(license), spdxExcluder)
+                            ) {
                                 licenseMatch = true;
                             }
                         }
                     });
-                    if(!licenseMatch) {
+                    if (!licenseMatch) {
                         filtered[item] = sorted[item];
                     }
                 }
             });
         } else {
             filtered = sorted;
+        }
+
+        var restricted;
+        if (options.packages) {
+            var packages = options.packages.split(';');
+            restricted = {};
+            Object.keys(filtered).map(function(key) {
+                if (packages.includes(key)) {
+                    restricted[key] = filtered[key];
+                }
+            });
+        } else {
+            restricted = filtered;
         }
 
         if (!Object.keys(sorted).length) {
@@ -433,7 +521,7 @@ exports.init = function(options, callback) {
         }
 
         //Return the callback and variables nicely
-        callback(inputError, filtered);
+        callback(inputError, restricted);
     });
 };
 
@@ -451,15 +539,19 @@ exports.asSummary = function(sorted) {
     var sortedLicenseCountObj = {};
 
     Object.keys(sorted).forEach(function(key) {
-        /*istanbul ignore else*/
+    /*istanbul ignore else*/
         if (sorted[key].licenses) {
-            licenseCountObj[sorted[key].licenses] = licenseCountObj[sorted[key].licenses] || 0;
+            licenseCountObj[sorted[key].licenses] =
+        licenseCountObj[sorted[key].licenses] || 0;
             licenseCountObj[sorted[key].licenses]++;
         }
     });
 
     Object.keys(licenseCountObj).forEach(function(license) {
-        licenceCountArray.push({ license: license, count: licenseCountObj[license] });
+        licenceCountArray.push({
+            license: license,
+            count: licenseCountObj[license],
+        });
     });
 
     /*istanbul ignore next*/
@@ -475,13 +567,17 @@ exports.asSummary = function(sorted) {
 };
 
 exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
-    var text = [], textArr = [], lineArr = [];
+    var text = [],
+        textArr = [],
+        lineArr = [];
     var prefixName = '"component"';
     var prefix = csvComponentPrefix;
 
     if (customFormat && Object.keys(customFormat).length > 0) {
         textArr = [];
-        if (csvComponentPrefix) { textArr.push(prefixName); }
+        if (csvComponentPrefix) {
+            textArr.push(prefixName);
+        }
         textArr.push('"module name"');
         Object.keys(customFormat).forEach(function forEachCallback(item) {
             textArr.push('"' + item + '"');
@@ -490,8 +586,10 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
     } else {
         textArr = [];
         /*istanbul ignore next*/
-        if (csvComponentPrefix) { textArr.push(prefixName); }
-        ['"module name"','"license"','"repository"'].forEach(function(item) {
+        if (csvComponentPrefix) {
+            textArr.push(prefixName);
+        }
+        ['"module name"', '"license"', '"repository"'].forEach(function(item) {
             textArr.push(item);
         });
         text.push(textArr.join(','));
@@ -505,7 +603,7 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
         //Grab the custom keys from the custom format
         if (customFormat && Object.keys(customFormat).length > 0) {
             if (csvComponentPrefix) {
-                lineArr.push('"'+prefix+'"');
+                lineArr.push('"' + prefix + '"');
             }
             lineArr.push('"' + key + '"');
             Object.keys(customFormat).forEach(function forEachCallback(item) {
@@ -515,12 +613,12 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
         } else {
             /*istanbul ignore next*/
             if (csvComponentPrefix) {
-                lineArr.push('"'+prefix+'"');
+                lineArr.push('"' + prefix + '"');
             }
             lineArr.push([
                 '"' + key + '"',
                 '"' + (module.licenses || '') + '"',
-                '"' + (module.repository || '') + '"'
+                '"' + (module.repository || '') + '"',
             ]);
             line = lineArr.join(',');
         }
@@ -531,20 +629,21 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
 };
 
 /**
-* Exports data as markdown (*.md) file which has it's own syntax.
-* @method
-* @param  {JSON} sorted       The sorted JSON data from all packages.
-* @param  {JSON} customFormat The custom format with information about the needed keys.
-* @return {String}            The returning plain text.
-*/
+ * Exports data as markdown (*.md) file which has it's own syntax.
+ * @method
+ * @param  {JSON} sorted       The sorted JSON data from all packages.
+ * @param  {JSON} customFormat The custom format with information about the needed keys.
+ * @return {String}            The returning plain text.
+ */
 exports.asMarkDown = function(sorted, customFormat) {
-
     var text = [];
     if (customFormat && Object.keys(customFormat).length > 0) {
         Object.keys(sorted).forEach(function sortedCallback(sortedItem) {
-            text.push(' - **[' + sortedItem + '](' + sorted[sortedItem].repository + ')**');
+            text.push(
+                ' - **[' + sortedItem + '](' + sorted[sortedItem].repository + ')**'
+            );
             Object.keys(customFormat).forEach(function customCallback(customItem) {
-                text.push('    - ' +  customItem + ': ' + sorted[sortedItem][customItem]);
+                text.push('    - ' + customItem + ': ' + sorted[sortedItem][customItem]);
             });
         });
         text = text.join('\n');
@@ -565,7 +664,7 @@ exports.parseJson = function(jsonPath) {
     }
 
     var jsonFileContents = '',
-        result = { };
+        result = {};
 
     try {
         jsonFileContents = fs.readFileSync(jsonPath, { encoding: 'utf8' });
@@ -580,17 +679,21 @@ exports.asFiles = function(json, outDir) {
     mkdirp.sync(outDir);
     Object.keys(json).forEach(function(moduleName) {
         var licenseFile = json[moduleName].licenseFile,
-            fileContents, outFileName, outPath, baseDir;
+            fileContents,
+            outFileName,
+            outPath,
+            baseDir;
 
         if (licenseFile && fs.existsSync(licenseFile)) {
             fileContents = fs.readFileSync(licenseFile);
-            outFileName = stripColor(moduleName).replace(/(\s+|@|\/)/g, "") + "-LICENSE.txt";
+            outFileName =
+        stripColor(moduleName).replace(/(\s+|@|\/)/g, '') + '-LICENSE.txt';
             outPath = path.join(outDir, outFileName);
             baseDir = path.dirname(outPath);
             mkdirp.sync(baseDir);
-            fs.writeFileSync(outPath, fileContents, "utf8");
+            fs.writeFileSync(outPath, fileContents, 'utf8');
         } else {
-            console.warn("no license file found for: " + moduleName);
+            console.warn('no license file found for: ' + moduleName);
         }
     });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var licenseFiles = require('./license-files');
 var debug = require('debug');
 var mkdirp = require('mkdirp');
 var spdxSatisfies = require('spdx-satisfies');
-var spdxCorrect = require('spdx-correct');
+var spdxCorrect =require('spdx-correct');
 var stripColor = require('strip-ansi');
 
 // Set up debug logging
@@ -33,11 +33,7 @@ var flatten = function(options) {
         colorize = options.color,
         unknown = options.unknown,
         readmeFile,
-        licenseData,
-        dirFiles,
-        files = [],
-        noticeFiles = [],
-        licenseFile;
+        licenseData, dirFiles, files = [], noticeFiles = [], licenseFile;
 
     /*istanbul ignore next*/
     if (colorize) {
@@ -57,10 +53,7 @@ var flatten = function(options) {
         return data;
     }
 
-    if (
-        (options.production && json.extraneous) ||
-    (options.development && !json.extraneous && !json.root)
-    ) {
+    if ((options.production && json.extraneous) || (options.development && !json.extraneous && !json.root)) {
         return data;
     }
 
@@ -68,52 +61,34 @@ var flatten = function(options) {
 
     // Include property in output unless custom format has set property to false.
     var include = function(property) {
-        return (
-            options.customFormat === undefined ||
-      options.customFormat[property] !== false
-        );
+        return (options.customFormat === undefined || options.customFormat[property] !== false);
     };
 
-    if (include('repository') && json.repository) {
-    /*istanbul ignore else*/
-        if (
-            typeof json.repository === 'object' &&
-      typeof json.repository.url === 'string'
-        ) {
-            moduleInfo.repository = json.repository.url.replace(
-                'git+ssh://git@',
-                'git://'
-            );
-            moduleInfo.repository = moduleInfo.repository.replace(
-                'git+https://github.com',
-                'https://github.com'
-            );
-            moduleInfo.repository = moduleInfo.repository.replace(
-                'git://github.com',
-                'https://github.com'
-            );
-            moduleInfo.repository = moduleInfo.repository.replace(
-                'git@github.com:',
-                'https://github.com/'
-            );
+    if (include("repository") && json.repository) {
+        /*istanbul ignore else*/
+        if (typeof json.repository === 'object' && typeof json.repository.url === 'string') {
+            moduleInfo.repository = json.repository.url.replace('git+ssh://git@', 'git://');
+            moduleInfo.repository = moduleInfo.repository.replace('git+https://github.com', 'https://github.com');
+            moduleInfo.repository = moduleInfo.repository.replace('git://github.com', 'https://github.com');
+            moduleInfo.repository = moduleInfo.repository.replace('git@github.com:', 'https://github.com/');
             moduleInfo.repository = moduleInfo.repository.replace(/\.git$/, '');
         }
     }
-    if (include('url') && json.url) {
-    /*istanbul ignore next*/
+    if (include("url") && json.url) {
+        /*istanbul ignore next*/
         if (typeof json.url === 'object') {
             moduleInfo.url = json.url.web;
         }
     }
     if (json.author && typeof json.author === 'object') {
-    /*istanbul ignore else - This should always be there*/
-        if (include('publisher') && json.author.name) {
+        /*istanbul ignore else - This should always be there*/
+        if (include("publisher") && json.author.name) {
             moduleInfo.publisher = json.author.name;
         }
-        if (include('email') && json.author.email) {
+        if (include("email") && json.author.email) {
             moduleInfo.email = json.author.email;
         }
-        if (include('url') && json.author.url) {
+        if (include("url") && json.author.url) {
             moduleInfo.url = json.author.url;
         }
     }
@@ -137,17 +112,13 @@ var flatten = function(options) {
         });
     }
 
-    if (include('path') && json.path && typeof json.path === 'string') {
+    if (include("path") && json.path && typeof json.path === 'string') {
         moduleInfo.path = json.path;
     }
 
     licenseData = json.license || json.licenses || undefined;
 
-    if (
-        json.path &&
-    (!json.readme ||
-      json.readme.toLowerCase().indexOf('no readme data found') > -1)
-    ) {
+    if (json.path && (!json.readme || json.readme.toLowerCase().indexOf('no readme data found') > -1)) {
         readmeFile = path.join(json.path, 'README.md');
         /*istanbul ignore if*/
         if (fs.existsSync(readmeFile)) {
@@ -156,9 +127,9 @@ var flatten = function(options) {
     }
 
     if (licenseData) {
-    /*istanbul ignore else*/
+        /*istanbul ignore else*/
         if (Array.isArray(licenseData) && licenseData.length > 0) {
-            moduleInfo.licenses = licenseData.map(function(license) {
+            moduleInfo.licenses = licenseData.map(function(license){
                 /*istanbul ignore else*/
                 if (typeof license === 'object') {
                     /*istanbul ignore next*/
@@ -167,10 +138,7 @@ var flatten = function(options) {
                     return license;
                 }
             });
-        } else if (
-            typeof licenseData === 'object' &&
-      (licenseData.type || licenseData.name)
-        ) {
+        } else if (typeof licenseData === 'object' && (licenseData.type || licenseData.name)) {
             moduleInfo.licenses = license(licenseData.type || licenseData.name);
         } else if (typeof licenseData === 'string') {
             moduleInfo.licenses = license(licenseData);
@@ -180,7 +148,7 @@ var flatten = function(options) {
     }
 
     if (Array.isArray(moduleInfo.licenses)) {
-    /*istanbul ignore else*/
+        /*istanbul ignore else*/
         if (moduleInfo.licenses.length === 1) {
             moduleInfo.licenses = moduleInfo.licenses[0];
         }
@@ -204,11 +172,7 @@ var flatten = function(options) {
         /*istanbul ignore else*/
         if (fs.lstatSync(licenseFile).isFile()) {
             var content;
-            if (
-                !moduleInfo.licenses ||
-        moduleInfo.licenses.indexOf(UNKNOWN) > -1 ||
-        moduleInfo.licenses.indexOf('Custom:') === 0
-            ) {
+            if (!moduleInfo.licenses || moduleInfo.licenses.indexOf(UNKNOWN) > -1 || moduleInfo.licenses.indexOf('Custom:') === 0) {
                 //Only re-check the license if we didn't get it from elsewhere
                 content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                 moduleInfo.licenses = license(content);
@@ -217,13 +181,11 @@ var flatten = function(options) {
             if (index === 0) {
                 // Treat the file with the highest precedence as licenseFile
                 /*istanbul ignore else*/
-                if (include('licenseFile')) {
-                    moduleInfo.licenseFile = options.basePath
-                        ? path.relative(options.basePath, licenseFile)
-                        : licenseFile;
+                if (include("licenseFile")) {
+                    moduleInfo.licenseFile = options.basePath ? path.relative(options.basePath, licenseFile) : licenseFile;
                 }
 
-                if (include('licenseText') && options.customFormat) {
+                if (include("licenseText") && options.customFormat) {
                     if (!content) {
                         content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                     }
@@ -231,14 +193,11 @@ var flatten = function(options) {
                     if (options._args && !options._args.csv) {
                         moduleInfo.licenseText = content.trim();
                     } else {
-                        moduleInfo.licenseText = content
-                            .replace(/"/g, "'")
-                            .replace(/\r?\n|\r/g, ' ')
-                            .trim();
+                        moduleInfo.licenseText = content.replace(/"/g, '\'').replace(/\r?\n|\r/g, " ").trim();
                     }
                 }
 
-                if (include('copyright') && options.customFormat) {
+                if(include('copyright') && options.customFormat) {
                     if (!content) {
                         content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
                     }
@@ -247,25 +206,23 @@ var flatten = function(options) {
                         .replace(/\r\n/g, '\n')
                         .split('\n\n')
                         .filter(function selectCopyRightStatements(value) {
-                            return (
-                                value.startsWith('opyright', 1) && // include copyright statements
-                !value.startsWith('opyright notice', 1) && // exclude lines from from license text
-                !value.startsWith('opyright and related rights', 1)
-                            );
+                            return value.startsWith('opyright', 1) &&         // include copyright statements
+                                !value.startsWith('opyright notice', 1) &&    // exclude lines from from license text
+                                !value.startsWith('opyright and related rights', 1);
                         })
                         .filter(function removeDuplicates(value, index, list) {
                             return index === 0 || value !== list[0];
                         });
 
-                    if (linesWithCopyright.length > 0) {
+                    if(linesWithCopyright.length > 0) {
                         moduleInfo.copyright = linesWithCopyright[0]
                             .replace(/\n/g, '. ')
                             .trim();
                     }
-
+                
                     // Mark files with multiple copyright statements. This might be
                     // an indicator to take a closer look at the LICENSE file.
-                    if (linesWithCopyright.length > 1) {
+                    if(linesWithCopyright.length > 1) {
                         moduleInfo.copyright += '*';
                     }
                 }
@@ -277,9 +234,7 @@ var flatten = function(options) {
         var file = path.join(json.path, filename);
         /*istanbul ignore else*/
         if (fs.lstatSync(file).isFile()) {
-            moduleInfo.noticeFile = options.basePath
-                ? path.relative(options.basePath, file)
-                : file;
+            moduleInfo.noticeFile = options.basePath ? path.relative(options.basePath, file) : file;
         }
     });
 
@@ -288,8 +243,7 @@ var flatten = function(options) {
         Object.keys(json.dependencies).forEach(function(name) {
             var childDependency = json.dependencies[name],
                 dependencyId = childDependency.name + '@' + childDependency.version;
-            if (data[dependencyId]) {
-                // already exists
+            if (data[dependencyId]) { // already exists
                 return;
             }
             data = flatten({
@@ -301,7 +255,7 @@ var flatten = function(options) {
                 production: options.production,
                 development: options.development,
                 basePath: options.basePath,
-                _args: options._args,
+                _args: options._args
             });
         });
     }
@@ -319,7 +273,7 @@ exports.init = function(options, callback) {
     }
     var opts = {
         dev: true,
-        log: debugLog,
+        log: debugLog
     };
 
     if (options.production || options.development) {
@@ -357,16 +311,14 @@ exports.init = function(options, callback) {
                 production: options.production,
                 development: options.development,
                 basePath: options.relativeLicensePath ? json.path : null,
-                _args: options,
+                _args: options
             }),
             colorize = options.color,
             sorted = {},
             filtered = {},
-            exclude =
-        options.exclude &&
-        options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
-            return license.replace(/\\,/g, ',').replace(/^\s+|\s+$/g, '');
-        }),
+            exclude = options.exclude && options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
+                return license.replace(/\\,/g, ',').replace(/^\s+|\s+$/g, '');
+            }),
             inputError = null;
 
         var colorizeString = function(string) {
@@ -374,121 +326,94 @@ exports.init = function(options, callback) {
             return colorize ? chalk.bold.red(string) : string;
         };
 
-        Object.keys(data)
-            .sort()
-            .forEach(function(item) {
-                if (toCheckforFailOn.length > 0) {
-                    if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
-                        console.error(
-                            'Found license defined by the --failOn flag: "' +
-                data[item].licenses +
-                '". Exiting.'
-                        );
-                        process.exit(1);
-                    }
+        Object.keys(data).sort().forEach(function(item) {
+            if (toCheckforFailOn.length > 0) {
+                if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
+                    console.error('Found license defined by the --failOn flag: "' + data[item].licenses + '". Exiting.');
+                    process.exit(1);
                 }
-                if (toCheckforOnlyAllow.length > 0) {
-                    var good = false;
-                    toCheckforOnlyAllow.forEach(function(k) {
-                        if (data[item].licenses.indexOf(k) === -1 && !good) {
-                            good = false;
-                        } else {
-                            good = true;
-                        }
-                    });
-                    if (!good) {
-                        console.error(
-                            'Found license NOT defined by the --onlyAllow flag: "' +
-                data[item].licenses +
-                '". Exiting.'
-                        );
-                        process.exit(1);
-                    }
-                }
-                if (data[item].private) {
-                    data[item].licenses = colorizeString(UNLICENSED);
-                }
-                /*istanbul ignore next*/
-                if (!data[item].licenses) {
-                    data[item].licenses = colorizeString(UNKNOWN);
-                }
-                if (options.unknown) {
-                    /*istanbul ignore else*/
-                    if (data[item].licenses && data[item].licenses !== UNKNOWN) {
-                        if (data[item].licenses.indexOf('*') > -1) {
-                            /*istanbul ignore if*/
-                            data[item].licenses = colorizeString(UNKNOWN);
-                        }
-                    }
-                }
-                /*istanbul ignore else*/
-                if (data[item]) {
-                    if (options.onlyunknown) {
-                        if (
-                            data[item].licenses.indexOf('*') > -1 ||
-              data[item].licenses.indexOf(UNKNOWN) > -1
-                        ) {
-                            sorted[item] = data[item];
-                        }
+            }
+            if (toCheckforOnlyAllow.length > 0) {
+                var good = false;
+                toCheckforOnlyAllow.forEach(function(k) {
+                    if (data[item].licenses.indexOf(k) === -1 && !good) {
+                        good = false;
                     } else {
+                        good = true;
+                    }
+                });
+                if (!good) {
+                    console.error('Found license NOT defined by the --onlyAllow flag: "' + data[item].licenses + '". Exiting.');
+                    process.exit(1);
+                }
+            }
+            if (data[item].private) {
+                data[item].licenses = colorizeString(UNLICENSED);
+            }
+            /*istanbul ignore next*/
+            if (!data[item].licenses) {
+                data[item].licenses = colorizeString(UNKNOWN);
+            }
+            if (options.unknown) {
+                /*istanbul ignore else*/
+                if (data[item].licenses && data[item].licenses !== UNKNOWN) {
+                    if (data[item].licenses.indexOf('*') > -1) {
+                        /*istanbul ignore if*/
+                        data[item].licenses = colorizeString(UNKNOWN);
+                    }
+                }
+            }
+            /*istanbul ignore else*/
+            if (data[item]) {
+                if (options.onlyunknown) {
+                    if (data[item].licenses.indexOf('*') > -1 ||
+                        data[item].licenses.indexOf(UNKNOWN) > -1) {
                         sorted[item] = data[item];
                     }
+                } else {
+                    sorted[item] = data[item];
                 }
-            });
+            }
+        });
         if (exclude) {
             var transformBSD = function(spdx) {
-                return spdx === 'BSD'
-                    ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)'
-                    : spdx;
+                return spdx === 'BSD' ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)' : spdx;
             };
-            var invert = function(fn) {
-                return function(spdx) {
-                    return !fn(spdx);
-                };
-            };
-            var spdxIsValid = function(spdx) {
-                return spdxCorrect(spdx) === spdx;
-            };
+            var invert = function(fn) { return function(spdx) { return !fn(spdx);};};
+            var spdxIsValid = function(spdx) { return spdxCorrect(spdx) === spdx; };
 
             var validSPDXLicenses = exclude.map(transformBSD).filter(spdxIsValid);
-            var invalidSPDXLicenses = exclude
-                .map(transformBSD)
-                .filter(invert(spdxIsValid));
+            var invalidSPDXLicenses = exclude.map(transformBSD).filter(invert(spdxIsValid));
             var spdxExcluder = '( ' + validSPDXLicenses.join(' OR ') + ' )';
 
             Object.keys(sorted).forEach(function(item) {
                 var licenses = sorted[item].licenses;
                 /*istanbul ignore if - just for protection*/
-                if (!licenses) {
+                if(!licenses) {
                     filtered[item] = sorted[item];
                 } else {
                     licenses = [].concat(licenses);
                     var licenseMatch = false;
                     licenses.forEach(function(license) {
                         /*istanbul ignore if - just for protection*/
-                        if (license.indexOf(UNKNOWN) >= 0) {
-                            // necessary due to colorization
+                        if (license.indexOf(UNKNOWN) >= 0) { // necessary due to colorization
                             filtered[item] = sorted[item];
                         } else {
-                            if (license.indexOf('*') >= 0) {
+                            if(license.indexOf('*') >= 0) {
                                 license = license.substring(0, license.length - 1);
                             }
-                            if (license === 'BSD') {
-                                license =
-                  '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)';
+                            if(license === 'BSD') {
+                                license = '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)';
                             }
 
                             if (invalidSPDXLicenses.indexOf(license) >= 0) {
                                 licenseMatch = true;
-                            } else if (
-                                spdxCorrect(license) &&
-                spdxSatisfies(spdxCorrect(license), spdxExcluder)
-                            ) {
+                            } else if (spdxCorrect(license) && spdxSatisfies(spdxCorrect(license), spdxExcluder)) {
                                 licenseMatch = true;
                             }
                         }
                     });
-                    if (!licenseMatch) {
+                    if(!licenseMatch) {
                         filtered[item] = sorted[item];
                     }
                 }
@@ -539,19 +464,15 @@ exports.asSummary = function(sorted) {
     var sortedLicenseCountObj = {};
 
     Object.keys(sorted).forEach(function(key) {
-    /*istanbul ignore else*/
+        /*istanbul ignore else*/
         if (sorted[key].licenses) {
-            licenseCountObj[sorted[key].licenses] =
-        licenseCountObj[sorted[key].licenses] || 0;
+            licenseCountObj[sorted[key].licenses] = licenseCountObj[sorted[key].licenses] || 0;
             licenseCountObj[sorted[key].licenses]++;
         }
     });
 
     Object.keys(licenseCountObj).forEach(function(license) {
-        licenceCountArray.push({
-            license: license,
-            count: licenseCountObj[license],
-        });
+        licenceCountArray.push({ license: license, count: licenseCountObj[license] });
     });
 
     /*istanbul ignore next*/
@@ -567,17 +488,13 @@ exports.asSummary = function(sorted) {
 };
 
 exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
-    var text = [],
-        textArr = [],
-        lineArr = [];
+    var text = [], textArr = [], lineArr = [];
     var prefixName = '"component"';
     var prefix = csvComponentPrefix;
 
     if (customFormat && Object.keys(customFormat).length > 0) {
         textArr = [];
-        if (csvComponentPrefix) {
-            textArr.push(prefixName);
-        }
+        if (csvComponentPrefix) { textArr.push(prefixName); }
         textArr.push('"module name"');
         Object.keys(customFormat).forEach(function forEachCallback(item) {
             textArr.push('"' + item + '"');
@@ -586,10 +503,8 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
     } else {
         textArr = [];
         /*istanbul ignore next*/
-        if (csvComponentPrefix) {
-            textArr.push(prefixName);
-        }
-        ['"module name"', '"license"', '"repository"'].forEach(function(item) {
+        if (csvComponentPrefix) { textArr.push(prefixName); }
+        ['"module name"','"license"','"repository"'].forEach(function(item) {
             textArr.push(item);
         });
         text.push(textArr.join(','));
@@ -603,7 +518,7 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
         //Grab the custom keys from the custom format
         if (customFormat && Object.keys(customFormat).length > 0) {
             if (csvComponentPrefix) {
-                lineArr.push('"' + prefix + '"');
+                lineArr.push('"'+prefix+'"');
             }
             lineArr.push('"' + key + '"');
             Object.keys(customFormat).forEach(function forEachCallback(item) {
@@ -613,12 +528,12 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
         } else {
             /*istanbul ignore next*/
             if (csvComponentPrefix) {
-                lineArr.push('"' + prefix + '"');
+                lineArr.push('"'+prefix+'"');
             }
             lineArr.push([
                 '"' + key + '"',
                 '"' + (module.licenses || '') + '"',
-                '"' + (module.repository || '') + '"',
+                '"' + (module.repository || '') + '"'
             ]);
             line = lineArr.join(',');
         }
@@ -629,21 +544,20 @@ exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
 };
 
 /**
- * Exports data as markdown (*.md) file which has it's own syntax.
- * @method
- * @param  {JSON} sorted       The sorted JSON data from all packages.
- * @param  {JSON} customFormat The custom format with information about the needed keys.
- * @return {String}            The returning plain text.
- */
+* Exports data as markdown (*.md) file which has it's own syntax.
+* @method
+* @param  {JSON} sorted       The sorted JSON data from all packages.
+* @param  {JSON} customFormat The custom format with information about the needed keys.
+* @return {String}            The returning plain text.
+*/
 exports.asMarkDown = function(sorted, customFormat) {
+
     var text = [];
     if (customFormat && Object.keys(customFormat).length > 0) {
         Object.keys(sorted).forEach(function sortedCallback(sortedItem) {
-            text.push(
-                ' - **[' + sortedItem + '](' + sorted[sortedItem].repository + ')**'
-            );
+            text.push(' - **[' + sortedItem + '](' + sorted[sortedItem].repository + ')**');
             Object.keys(customFormat).forEach(function customCallback(customItem) {
-                text.push('    - ' + customItem + ': ' + sorted[sortedItem][customItem]);
+                text.push('    - ' +  customItem + ': ' + sorted[sortedItem][customItem]);
             });
         });
         text = text.join('\n');
@@ -664,7 +578,7 @@ exports.parseJson = function(jsonPath) {
     }
 
     var jsonFileContents = '',
-        result = {};
+        result = { };
 
     try {
         jsonFileContents = fs.readFileSync(jsonPath, { encoding: 'utf8' });
@@ -679,21 +593,17 @@ exports.asFiles = function(json, outDir) {
     mkdirp.sync(outDir);
     Object.keys(json).forEach(function(moduleName) {
         var licenseFile = json[moduleName].licenseFile,
-            fileContents,
-            outFileName,
-            outPath,
-            baseDir;
+            fileContents, outFileName, outPath, baseDir;
 
         if (licenseFile && fs.existsSync(licenseFile)) {
             fileContents = fs.readFileSync(licenseFile);
-            outFileName =
-        stripColor(moduleName).replace(/(\s+|@|\/)/g, '') + '-LICENSE.txt';
+            outFileName = stripColor(moduleName).replace(/(\s+|@|\/)/g, "") + "-LICENSE.txt";
             outPath = path.join(outDir, outFileName);
             baseDir = path.dirname(outPath);
             mkdirp.sync(baseDir);
-            fs.writeFileSync(outPath, fileContents, 'utf8');
+            fs.writeFileSync(outPath, fileContents, "utf8");
         } else {
-            console.warn('no license file found for: ' + moduleName);
+            console.warn("no license file found for: " + moduleName);
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "Andrew Couch <andy@couchand.com>",
     "Asharma <Asharma@agtinternational.com>",
     "Bryan English <bryan@bryanenglish.com>",
+    "Christoph Werner <christoph@codepunkt.de>",
     "Cory Reed <creed@mrn.org>",
     "Damien Larmine <damien.larmine@gmail.com>",
     "Dan Rumney <dancrumb@gmail.com>",

--- a/tests/packages-test.js
+++ b/tests/packages-test.js
@@ -1,0 +1,23 @@
+var assert = require('assert'),
+    path = require('path'),
+    spawn = require('child_process').spawn,
+    restrictedPackages = [
+        'readable-stream@1.1.14',
+        'spdx-satisfies@4.0.0',
+        'y18n@3.2.1',
+    ];
+
+describe('bin/license-checker', function() {
+    this.timeout(8000);
+
+    it('should restrict the output to the provided packages', function(done) {
+        var node = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--json', '--packages', restrictedPackages.join(';')], {
+            cwd: path.join(__dirname, '../'),
+        });
+        
+        node.stdout.on('data', function(data) {
+            assert.deepEqual(Object.keys(JSON.parse(data.toString())), restrictedPackages);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Hello everyone and a special hello to @davglass!

Thanks for this amazing package - it helps me not implement a lot of things i'd otherwise have to implement! 👍 

Until now, restricting the generated output to specific packages (and versions) is not possible.
In an environment where a legal department has to check every open source license that is part of a delivered product, the only way to handle this with the current version of `license-checker` is to scan **all** dependencies (including devDependencies).

Using the `--production` switch is not feasible in this scenario, because especially in frontend applications that are built using tooling such as `webpack`, `parcel`, `rollup`, `browserify` or others, the tools unfortunately don't care if a dependency that is included in a build artifact was listed as a or derived from a devDependency or a dependency.

Because the bulk of our builds is done with `webpack`, i'm implementing a webpack plugin that generates a list of packages and versions that are actually part of a build output and would love to use depend on `license-checker` to do the heavy-lifting in regards to checking licenses. To do so, i need a way to restrict the `license-checker` output to specific packages and versions while ignoring the rest.

Another way to deal with this would be to expose a method that can check the license of a single package, but that would involve a lot of refactoring, dealing with `read-installed` and more. I've tried it and it did not look & feel well.

Therefore, i've implemented an additional CLI switch called `--packages` that accepts a semicolon-separated list of package@version identifiers and restricts the output of `license-checker` to these packages. The code changes are minimal because all packages read by `read-installed` are checked and the filtered return value is then restricted to the given packages.

I'm aware that this is not the most performant solution, but i'm perfectly fine with that because i did not have to introduce a lot of changes and `license-checker` is pretty fast regardless.