### PR TITLE
Add an excludePackages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Options
 * `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
 * `--onlyAllow [list]` fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list
 * `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
+* `--exclude-packages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
 
 Exclusions
 ----------
@@ -104,6 +105,7 @@ license-checker --unknown
 license-checker --customPath customFormatExample.json
 license-checker --exclude 'MIT, MIT OR X11, BSD, ISC'
 license-checker --packages 'react@16.3.0;react-dom@16.3.0;lodash@4.3.1'
+license-checker --excludePackages 'internal-1;internal-2'
 license-checker --onlyunknown
 ```
 

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -38,6 +38,7 @@ if (args.help) {
         '   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list',
         '   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list',
         '   --packages [list] restrict output to the packages (package@version) in the semicolon-seperated list',
+        '   --excludePackages [list] restrict output to the packages (package@version) not in the semicolon-seperated list',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',

--- a/lib/args.js
+++ b/lib/args.js
@@ -28,7 +28,8 @@ var nopt = require('nopt'),
         summary: Boolean,
         failOn: String,
         onlyAllow: String,
-        packages: String
+        packages: String,
+        excludePackages: String,
     },
     shorts = {
         "v": ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -422,7 +422,9 @@ exports.init = function(options, callback) {
             filtered = sorted;
         }
 
-        var restricted;
+        var restricted = filtered;
+
+        // package whitelist
         if (options.packages) {
             var packages = options.packages.split(';');
             restricted = {};
@@ -431,8 +433,17 @@ exports.init = function(options, callback) {
                     restricted[key] = filtered[key];
                 }
             });
-        } else {
-            restricted = filtered;
+        }
+
+        // package blacklist
+        if (options.excludePackages) {
+            var excludedPackages = options.excludePackages.split(';');
+            restricted = {};
+            Object.keys(filtered).map(function(key) {
+                if (!excludedPackages.includes(key)) {
+                    restricted[key] = filtered[key];
+                }
+            });
         }
 
         if (!Object.keys(sorted).length) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "Dick Wiggers <dickje@gmail.com>",
     "Drew Folta <drew@folta.net>",
     "Elijah Insua <tmpvar@gmail.com>",
+    "François Zaninotto <fzaninotto@gmail.com>",
     "Glen Arrowsmith <glen.arrowsmith@gmail.com>",
     "Helio Frota <00hf11@gmail.com>",
     "Holger Knust <holger.knust@certusview.com>",

--- a/tests/packages-test.js
+++ b/tests/packages-test.js
@@ -1,23 +1,36 @@
 var assert = require('assert'),
     path = require('path'),
-    spawn = require('child_process').spawn,
-    restrictedPackages = [
-        'readable-stream@1.1.14',
-        'spdx-satisfies@4.0.0',
-        'y18n@3.2.1',
-    ];
+    spawn = require('child_process').spawnSync;
 
 describe('bin/license-checker', function() {
     this.timeout(8000);
 
-    it('should restrict the output to the provided packages', function(done) {
-        var node = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--json', '--packages', restrictedPackages.join(';')], {
+    it('should restrict the output to the provided packages', function() {
+        var restrictedPackages = [
+            'readable-stream@1.1.14',
+            'spdx-satisfies@4.0.0',
+            'y18n@3.2.1',
+        ];
+        var output = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--json', '--packages', restrictedPackages.join(';')], {
+            cwd: path.join(__dirname, '../'),
+        });
+
+        assert.deepEqual(Object.keys(JSON.parse(output.stdout.toString())), restrictedPackages);
+    });
+
+    it('should exclude provided excludedPackages from the output', function() {
+        var excludedPackages = [
+            'readable-stream@1.1.14',
+            'spdx-satisfies@4.0.0',
+            'y18n@3.2.1',
+        ];
+        var output = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--json', '--excludePackages', excludedPackages.join(';')], {
             cwd: path.join(__dirname, '../'),
         });
         
-        node.stdout.on('data', function(data) {
-            assert.deepEqual(Object.keys(JSON.parse(data.toString())), restrictedPackages);
-            done();
+        var packages = Object.keys(JSON.parse(output.stdout.toString()));
+        excludedPackages.forEach(package => {
+            assert.ok(!packages.includes(package));
         });
     });
 });


### PR DESCRIPTION
This option offers to whitelist some packages. It is useful to exclude private packages, which may come out as UNLICENSED and make the check fail (false positives).

Closes #163 and #171
