### PR TITLE
Improve --onlyAllow violation Error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -350,7 +350,7 @@ exports.init = function(options, callback) {
                     }
                 });
                 if (!good) {
-                    console.error('Found license NOT defined by the --onlyAllow flag: "' + data[item].licenses + '". Exiting.');
+                    console.error('Package "' + item + '" is licensed under "' + data[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
                     process.exit(1);
                 }
             }


### PR DESCRIPTION
Include the name of the package which triggered the error. IMHO this makes it easier to failures:

### Before
```
Found license NOT defined by the --onlyAllow flag: "ISC". Exiting.
```

### After
```
Package "foobar@1.0.0" is licensed under "ISC" which is not permitted by the --onlyAllow flag. Exiting.
```