### PR TITLE
Fixes #177, --packages and --excludePackages filtering

### DIFF
--- a/bin/license-checker
+++ b/bin/license-checker
@@ -13,11 +13,6 @@ var mkdirp = require('mkdirp');
 var path = require('path');
 var chalk = require('chalk');
 var fs = require('fs');
-var stripColor = require('strip-ansi');
-
-if (!args.color && (args.json || args.csv || args.out)) {
-    args.color = false;
-}
 
 if (args.help) {
     console.error('license-checker@' + require('../package.json').version);
@@ -72,6 +67,17 @@ checker.init(args, function(err, json) {
         console.error('Found error');
         console.error(err);
     }
+
+    if (shouldColorizeOutput(args)) {
+        var keys = Object.keys(json);
+        keys.forEach(function(key) {
+            var keyParts = key.split('@');
+            var colorizedKey = chalk.blue(keyParts[0]) + chalk.dim('@') + chalk.green(keyParts[1]);
+            json[colorizedKey] = json[key];
+            delete json[key];
+        });
+    }
+
     if (args.json) {
         formattedOutput = JSON.stringify(json, null, 2) + '\n';
     } else if (args.csv) {
@@ -89,10 +95,12 @@ checker.init(args, function(err, json) {
     } else if (args.out) {
         var dir = path.dirname(args.out);
         mkdirp.sync(dir);
-        //Remove the color tags
-        formattedOutput = stripColor(formattedOutput);
         fs.writeFileSync(args.out, formattedOutput, 'utf8');
     } else {
         console.log(formattedOutput);
     }
 });
+
+function shouldColorizeOutput(args) {
+    return args.color && !args.out && !(args.csv || args.json || args.markdown);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,6 @@ var debug = require('debug');
 var mkdirp = require('mkdirp');
 var spdxSatisfies = require('spdx-satisfies');
 var spdxCorrect =require('spdx-correct');
-var stripColor = require('strip-ansi');
 
 // Set up debug logging
 // https://www.npmjs.com/package/debug#stderr-vs-stdout
@@ -34,12 +33,6 @@ var flatten = function(options) {
         unknown = options.unknown,
         readmeFile,
         licenseData, dirFiles, files = [], noticeFiles = [], licenseFile;
-
-    /*istanbul ignore next*/
-    if (colorize) {
-        moduleInfo = { licenses: chalk.bold.red(UNKNOWN) };
-        key = chalk.blue(json.name) + chalk.dim('@') + chalk.green(json.version);
-    }
 
     if (json.private) {
         moduleInfo.private = true;
@@ -608,7 +601,7 @@ exports.asFiles = function(json, outDir) {
 
         if (licenseFile && fs.existsSync(licenseFile)) {
             fileContents = fs.readFileSync(licenseFile);
-            outFileName = stripColor(moduleName).replace(/(\s+|@|\/)/g, "") + "-LICENSE.txt";
+            outFileName = moduleName + "-LICENSE.txt";
             outPath = path.join(outDir, outFileName);
             baseDir = path.dirname(outPath);
             mkdirp.sync(baseDir);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "spdx": "^0.5.1",
     "spdx-correct": "^3.0.0",
     "spdx-satisfies": "^4.0.0",
-    "strip-ansi": "^4.0.0",
     "treeify": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The filtering logic for both `--packages` and `--excludePackages` was broken if the output was being colorized.

To work around this I have moved the colorization out of the parsing logic and into the formatting.

WRT to removing `strip-ansi`, I'm not convinced this package was actually being imported anywhere before this change, but I couldn't find  it referenced anywhere in the code so I've removed it for good hygine.