### PR TITLE
Fixes 176, Packages are not ignored when using --onlyAllow and --excludePackages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -320,32 +320,12 @@ exports.init = function(options, callback) {
         };
 
         Object.keys(data).sort().forEach(function(item) {
-            if (toCheckforFailOn.length > 0) {
-                if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
-                    console.error('Found license defined by the --failOn flag: "' + data[item].licenses + '". Exiting.');
-                    process.exit(1);
-                }
-            }
             if (data[item].private) {
                 data[item].licenses = colorizeString(UNLICENSED);
             }
             /*istanbul ignore next*/
             if (!data[item].licenses) {
                 data[item].licenses = colorizeString(UNKNOWN);
-            }
-            if (toCheckforOnlyAllow.length > 0) {
-                var good = false;
-                toCheckforOnlyAllow.forEach(function(k) {
-                    if (data[item].licenses.indexOf(k) === -1 && !good) {
-                        good = false;
-                    } else {
-                        good = true;
-                    }
-                });
-                if (!good) {
-                    console.error('Package "' + item + '" is licensed under "' + data[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
-                    process.exit(1);
-                }
             }
             if (options.unknown) {
                 /*istanbul ignore else*/
@@ -368,6 +348,11 @@ exports.init = function(options, callback) {
                 }
             }
         });
+
+        if (!Object.keys(sorted).length) {
+            err = new Error('No packages found in this path..');
+        }
+
         if (exclude) {
             var transformBSD = function(spdx) {
                 return spdx === 'BSD' ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)' : spdx;
@@ -439,9 +424,28 @@ exports.init = function(options, callback) {
             });
         }
 
-        if (!Object.keys(sorted).length) {
-            err = new Error('No packages found in this path..');
-        }
+        Object.keys(restricted).forEach(function(item) {
+            if (toCheckforFailOn.length > 0) {
+                if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
+                    console.error('Found license defined by the --failOn flag: "' + restricted[item].licenses + '". Exiting.');
+                    process.exit(1);
+                }
+            }
+            if (toCheckforOnlyAllow.length > 0) {
+                var good = false;
+                toCheckforOnlyAllow.forEach(function(k) {
+                    if (restricted[item].licenses.indexOf(k) === -1 && !good) {
+                        good = false;
+                    } else {
+                        good = true;
+                    }
+                });
+                if (!good) {
+                    console.error('Package "' + item + '" is licensed under "' + restricted[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
+                    process.exit(1);
+                }
+            }
+        });
 
         /*istanbul ignore next*/
         if (err) {


### PR DESCRIPTION
Moves the `--onlyAllow` and `--failOn` checks so that they are performed after the filtering performed by `--packages` and `--excludePackages`.