### PR TITLE
Feature: Exclude Private Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Options
 * `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
 * `--onlyAllow [list]` fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list
 * `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
-* `--exclude-packages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
+* `--excludePackages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
+* `--excludePrivatePackages` restrict output to not include any package marked as private
 
 Exclusions
 ----------

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -34,6 +34,7 @@ if (args.help) {
         '   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list',
         '   --packages [list] restrict output to the packages (package@version) in the semicolon-seperated list',
         '   --excludePackages [list] restrict output to the packages (package@version) not in the semicolon-seperated list',
+        '   --excludePrivatePackages restrict output to not include any package marked as private',
         '',
         '   --version The current version',
         '   --help  The text you are reading right now :)',

--- a/lib/args.js
+++ b/lib/args.js
@@ -30,6 +30,7 @@ var nopt = require('nopt'),
         onlyAllow: String,
         packages: String,
         excludePackages: String,
+        excludePrivatePackages: Boolean,
     },
     shorts = {
         "v": ["--version"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -320,32 +320,12 @@ exports.init = function(options, callback) {
         };
 
         Object.keys(data).sort().forEach(function(item) {
-            if (toCheckforFailOn.length > 0) {
-                if (toCheckforFailOn.indexOf(data[item].licenses) > -1) {
-                    console.error('Found license defined by the --failOn flag: "' + data[item].licenses + '". Exiting.');
-                    process.exit(1);
-                }
-            }
             if (data[item].private) {
                 data[item].licenses = colorizeString(UNLICENSED);
             }
             /*istanbul ignore next*/
             if (!data[item].licenses) {
                 data[item].licenses = colorizeString(UNKNOWN);
-            }
-            if (toCheckforOnlyAllow.length > 0) {
-                var good = false;
-                toCheckforOnlyAllow.forEach(function(k) {
-                    if (data[item].licenses.indexOf(k) === -1 && !good) {
-                        good = false;
-                    } else {
-                        good = true;
-                    }
-                });
-                if (!good) {
-                    console.error('Package "' + item + '" is licensed under "' + data[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
-                    process.exit(1);
-                }
             }
             if (options.unknown) {
                 /*istanbul ignore else*/
@@ -368,6 +348,11 @@ exports.init = function(options, callback) {
                 }
             }
         });
+
+        if (!Object.keys(sorted).length) {
+            err = new Error('No packages found in this path..');
+        }
+
         if (exclude) {
             var transformBSD = function(spdx) {
                 return spdx === 'BSD' ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)' : spdx;
@@ -439,9 +424,28 @@ exports.init = function(options, callback) {
             });
         }
 
-        if (!Object.keys(sorted).length) {
-            err = new Error('No packages found in this path..');
-        }
+        Object.keys(restricted).forEach(function(item) {
+            if (toCheckforFailOn.length > 0) {
+                if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
+                    console.error('Found license defined by the --failOn flag: "' + restricted[item].licenses + '". Exiting.');
+                    process.exit(1);
+                }
+            }
+            if (toCheckforOnlyAllow.length > 0) {
+                var good = false;
+                toCheckforOnlyAllow.forEach(function(k) {
+                    if (restricted[item].licenses.indexOf(k) === -1 && !good) {
+                        good = false;
+                    } else {
+                        good = true;
+                    }
+                });
+                if (!good) {
+                    console.error('Package "' + item + '" is licensed under "' + restricted[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
+                    process.exit(1);
+                }
+            }
+        });
 
         /*istanbul ignore next*/
         if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -424,6 +424,14 @@ exports.init = function(options, callback) {
             });
         }
 
+        if (options.excludePrivatePackages) {
+            Object.keys(filtered).forEach(function(key) {
+                if (restricted[key].private) {
+                    delete restricted[key];
+                }
+            });
+        }
+
         Object.keys(restricted).forEach(function(item) {
             if (toCheckforFailOn.length > 0) {
                 if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {

--- a/tests/packages-test.js
+++ b/tests/packages-test.js
@@ -29,8 +29,17 @@ describe('bin/license-checker', function() {
         });
         
         var packages = Object.keys(JSON.parse(output.stdout.toString()));
-        excludedPackages.forEach(package => {
-            assert.ok(!packages.includes(package));
+        excludedPackages.forEach(function(pkg) {
+            assert.ok(!packages.includes(pkg));
         });
+    });
+
+    it('should exclude private packages from the output', function() {
+        var output = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--json', '--excludePrivatePackages'], {
+            cwd: path.join(__dirname, 'fixtures', 'privateModule'),
+        });
+
+        var packages = Object.keys(JSON.parse(output.stdout.toString()));
+        assert.equal(packages.length, 0);
     });
 });


### PR DESCRIPTION
Restricts the output to not include any packages marked as private.

Internal projects typically do not carry any license information, however I do not want to have to ignore 'UNLICENSED' packages, nor do I want to have to meticulously list each module in the list of `--excludedPackages`.

Nb: this PR includes changes from #179 