### PR TITLE
Backtick in wrong place (formatting) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Options
 * `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
 * `--excludePackages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
 * `--excludePrivatePackages` restrict output to not include any package marked as private
-* `--direct look for direct dependencies only`
+* `--direct` look for direct dependencies only
 
 Exclusions
 ----------


### PR DESCRIPTION
Moved backtick so that definition of parameter is formatted properly