### PR TITLE
Fix custom format issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,20 +91,6 @@ var flatten = function(options) {
         moduleInfo.dependencyPath = json.path;
     }
 
-    /*istanbul ignore next*/
-    if (options.customFormat) {
-        Object.keys(options.customFormat).forEach(function forEachCallback(item) {
-            if (include(item) && json[item]) {
-                //For now, we only support strings, not JSON objects
-                if (typeof json[item] === 'string') {
-                    moduleInfo[item] = json[item];
-                }
-            } else if (include(item)) {
-                moduleInfo[item] = options.customFormat[item];
-            }
-        });
-    }
-
     if (include("path") && json.path && typeof json.path === 'string') {
         moduleInfo.path = json.path;
     }
@@ -255,6 +241,16 @@ var flatten = function(options) {
     if (!json.name || !json.version) {
         delete data[key];
     }
+
+    /*istanbul ignore next*/
+    if (options.customFormat) {
+        Object.keys(options.customFormat).forEach(function forEachCallback(item) {
+            if (include(item) && moduleInfo[item] === undefined) {
+                moduleInfo[item] = typeof json[item] === 'string' ? json[item] : options.customFormat[item];
+            }
+        });
+    }
+
     return data;
 };
 

--- a/tests/fixtures/author/package.json
+++ b/tests/fixtures/author/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "license-checker",
+  "version": "0.0.0",
+  "author": "Dav Glass <davglass@gmail.com>",
+  "license": "BSD-3-Clause"
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -475,6 +475,19 @@ describe('main tests', function() {
             });
         });
 
+        it('should return data for keys with different names in json vs custom format', function(done) {
+            checker.init({
+                start: path.join(__dirname, './fixtures/author'),
+                customFormat: {
+                    publisher: '',
+                }
+            }, function(err, filtered) {
+                assert.equal(Object.keys(filtered).length, 1);
+                assert.equal(filtered['license-checker@0.0.0'].publisher, 'Dav Glass');
+                done();
+            });
+        });
+
     });
 
     describe('should output the module location', function() {


### PR DESCRIPTION
Fixes an issue where specifying the following in custom json format will always return the default empty string value, rather than the value extracted from `json.author.name`
```
{
  "publisher": ""
}
```
