### PR TITLE
disabled colorization when called with --files option, added docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options
 * `--csv` output in csv format.
 * `--csvComponentPrefix` prefix column for component in csv format.
 * `--out [filepath]` write the data to a specific file.
+* `--files [path]` copy all license files to path and rename them to `module-name`@`version`-LICENSE.txt.
 * `--customPath` to add a custom Format file in JSON
 * `--exclude [list]` exclude modules which licenses are in the comma-separated list from the output
 * `--relativeLicensePath` output the location of the license files as relative paths

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -27,7 +27,7 @@ if (args.help) {
         '   --csv output in csv format.',
         '   --csvComponentPrefix column prefix for components in csv file',
         '   --out [filepath] write the data to a specific file.',
-        '   --files [path] copy all license files to path and rename them to <module-name>@<version>-LICENSE.txt.'
+        '   --files [path] copy all license files to path and rename them to <module-name>@<version>-LICENSE.txt.',
         '   --customPath to add a custom Format file in JSON',
         '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',
         '   --relativeLicensePath output the location of the license files as relative paths',
@@ -106,5 +106,5 @@ checker.init(args, function(err, json) {
 });
 
 function shouldColorizeOutput(args) {
-    return args.color && !args.out && !(args.csv || args.json || args.markdown || args.files);
+    return args.color && !args.out && !args.files && !(args.csv || args.json || args.markdown);
 }

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -27,6 +27,7 @@ if (args.help) {
         '   --csv output in csv format.',
         '   --csvComponentPrefix column prefix for components in csv file',
         '   --out [filepath] write the data to a specific file.',
+        '   --files [path] copy all license files to path and rename them to <module-name>@<version>-LICENSE.txt.'
         '   --customPath to add a custom Format file in JSON',
         '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',
         '   --relativeLicensePath output the location of the license files as relative paths',
@@ -105,5 +106,5 @@ checker.init(args, function(err, json) {
 });
 
 function shouldColorizeOutput(args) {
-    return args.color && !args.out && !(args.csv || args.json || args.markdown);
+    return args.color && !args.out && !(args.csv || args.json || args.markdown || args.files);
 }


### PR DESCRIPTION
This is a quick fix for issue https://github.com/davglass/license-checker/issues/209
* disabled colorization when called with --files option
* added documentation for --files