### PR TITLE
Extend the "Public Domain" Regex to handle dashes and underscores

### DIFF
--- a/lib/license.js
+++ b/lib/license.js
@@ -14,7 +14,7 @@ var APACHE = /\bApache License\b/;
 var WTFPL = /\bWTFPL\b/;
 // https://creativecommons.org/publicdomain/zero/1.0/
 var CC0_1_0 = /The\s+person\s+who\s+associated\s+a\s+work\s+with\s+this\s+deed\s+has\s+dedicated\s+the\s+work\s+to\s+the\s+public\s+domain\s+by\s+waiving\s+all\s+of\s+his\s+or\s+her\s+rights\s+to\s+the\s+work\s+worldwide\s+under\s+copyright\s+law,\s+including\s+all\s+related\s+and\s+neighboring\s+rights,\s+to\s+the\s+extent\s+allowed\s+by\s+law.\s+You\s+can\s+copy,\s+modify,\s+distribute\s+and\s+perform\s+the\s+work,\s+even\s+for\s+commercial\s+purposes,\s+all\s+without\s+asking\s+permission./i; // jshint ignore:line
-var PUBLIC_DOMAIN = /[Pp]ublic [Dd]omain/;
+var PUBLIC_DOMAIN = /[Pp]ublic[\-_ ]*[Dd]omain/;
 var IS_URL = /(https?:\/\/[-a-zA-Z0-9\/.]*)/;
 var IS_FILE_REFERENCE = /SEE LICENSE IN (.*)/i;
 

--- a/tests/license.js
+++ b/tests/license.js
@@ -128,6 +128,10 @@ describe('license parser', function() {
         assert.equal(data, 'Public Domain');
         data = license('Public domain');
         assert.equal(data, 'Public Domain');
+        data = license('Public-Domain');
+        assert.equal(data, 'Public Domain');
+        data = license('Public_Domain');
+        assert.equal(data, 'Public Domain');
     });
 
     it('License at URL check', function() {


### PR DESCRIPTION
I've found a number of packages that use the string `"Public-Domain"` or `"Public_Domain"` in the license string, which wasn't being handled by this module.

This pull request enables license-checker to handle these cases.