### PR TITLE
Correct a misplaced backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Options
 * `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
 * `--excludePackages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
 * `--excludePrivatePackages` restrict output to not include any package marked as private
-* `--direct look for direct dependencies only`
+* `--direct` look for direct dependencies only
 
 Exclusions
 ----------


### PR DESCRIPTION
The documentation for `--direct` had a backtick at the end of the line,
instead of after the flag.