### PR TITLE
Allow passing an array of packages with or without explicitly declare the package version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -417,7 +417,7 @@ exports.init = function(options, callback) {
                 // 1. the package full name. Ex: `react` (we suffix an '@' to ensure we don't match packages like `react-native`)
                 // 2. the package full name and the major version. Ex: `react@16`
                 // 3. the package full name and full version. Ex: `react@16.0.2`
-                if (packages.findIndex((package) => key.includes(package.includes('@') ? package : package + '@')) !== -1) {
+                if (packages.findIndex((package) => key.startsWith(package.indexOf('@') > 0 ? package : package + '@')) !== -1) {
                     restricted[key] = filtered[key];
                 }
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -299,6 +299,7 @@ exports.init = function(options, callback) {
         Array.isArray(options.packages) && options.packages ||
         typeof options.packages === 'string' && options.packages.split(';') ||
         false
+    );
 
     read(options.start, opts, function(err, json) {
         var data = flatten({

--- a/lib/index.js
+++ b/lib/index.js
@@ -417,7 +417,7 @@ exports.init = function(options, callback) {
                 // 1. the package full name. Ex: `react` (we suffix an '@' to ensure we don't match packages like `react-native`)
                 // 2. the package full name and the major version. Ex: `react@16`
                 // 3. the package full name and full version. Ex: `react@16.0.2`
-                if (packages.findIndex((package) => key.includes(package.includes('@') : package : package + '@')) !== -1) {
+                if (packages.findIndex((package) => key.includes(package.includes('@') ? package : package + '@')) !== -1) {
                     restricted[key] = filtered[key];
                 }
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,6 +294,11 @@ exports.init = function(options, callback) {
             }
         });
     }
+    
+    var packages = (
+        Array.isArray(options.packages) && options.packages ||
+        typeof options.packages === 'string' && options.packages.split(';') ||
+        false
 
     read(options.start, opts, function(err, json) {
         var data = flatten({
@@ -404,11 +409,10 @@ exports.init = function(options, callback) {
         var restricted = filtered;
 
         // package whitelist
-        if (options.packages) {
-            var packages = options.packages.split(';');
+        if (packages) {
             restricted = {};
             Object.keys(filtered).map(function(key) {
-                if (packages.includes(key)) {
+                if (packages.findIndex((package) => key.includes(package)) !== -1) {
                     restricted[key] = filtered[key];
                 }
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -413,7 +413,11 @@ exports.init = function(options, callback) {
         if (packages) {
             restricted = {};
             Object.keys(filtered).map(function(key) {
-                if (packages.findIndex((package) => key.includes(package)) !== -1) {
+                // Whitelist packages by declaring:
+                // 1. the package full name. Ex: `react` (we suffix an '@' to ensure we don't match packages like `react-native`)
+                // 2. the package full name and the major version. Ex: `react@16`
+                // 3. the package full name and full version. Ex: `react@16.0.2`
+                if (packages.findIndex((package) => key.includes(package.includes('@') : package : package + '@')) !== -1) {
                     restricted[key] = filtered[key];
                 }
             });


### PR DESCRIPTION
```js
await require("license-checker").init({
    // packages: [ 'react', 'react-native' ], // or
    // packages: 'react;react-native', // or
    // packages: 'react@16'
})
```

This will also allow the cli to accept package whitelisting with just the version's major or without version at all:
```js
license-checker --packages "react@16;react-native"
```