### PR TITLE
Replace `process.exit()` with throwing an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -437,8 +437,7 @@ exports.init = function(options, callback) {
         Object.keys(restricted).forEach(function(item) {
             if (toCheckforFailOn.length > 0) {
                 if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
-                    console.error('Found license defined by the --failOn flag: "' + restricted[item].licenses + '". Exiting.');
-                    process.exit(1);
+                    throw new Error('Found license defined by the --failOn flag: "' + restricted[item].licenses + '". Exiting.');
                 }
             }
             if (toCheckforOnlyAllow.length > 0) {
@@ -451,8 +450,7 @@ exports.init = function(options, callback) {
                     }
                 });
                 if (!good) {
-                    console.error('Package "' + item + '" is licensed under "' + restricted[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
-                    process.exit(1);
+                    throw new Error('Package "' + item + '" is licensed under "' + restricted[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
                 }
             }
         });


### PR DESCRIPTION
Using `process.exit()` does not allow us to use this tool programmatically, as we cannot then handle the error in a custom way (ie: formatting the response for CI, logging it somewhere, etc). 

This PR replaces `console.error` + using `process.exit` with throwing an error.  This will have the same effect in CLI usage by immediately terminating the process with a message, but can also be `try/catch` handled in a parent program.

A downside might be that the error output is less terse... but it will be more noticeable! 