### PR TITLE
Upgrade mkdirp to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "debug": "^3.1.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.3",
     "nopt": "^4.0.1",
     "read-installed": "~4.0.3",
     "semver": "^5.5.0",


### PR DESCRIPTION
Upgrade mkdirp to 0.5.3 due to Prototype Pollution of minimist

```sh
                       === npm audit security report ===                        
                                                                                
┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.3                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ license-checker                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ license-checker > mkdirp > minimist                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1179                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```