### PR TITLE
 Upgrade mkdirp to 1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - "6"
     - "8"
 cache:
     directories:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "debug": "^3.1.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.3",
     "nopt": "^4.0.1",
     "read-installed": "~4.0.3",
     "semver": "^5.5.0",


### PR DESCRIPTION
To fix npm warning about deprecated mkdirp@0.5.4

```
npm WARN deprecated mkdirp@0.5.4: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
```