### PR TITLE
Fix licenses of package when there are more than 1 file of potential …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v25.0.2 (2020/27/10 09:20 +00:00)
+- [5dcc73f](https://github.com/misak113/license-checker/commit/5dcc73f054182f04327c5117a5ab61e25cb6967a) Fix licenses of package when there are more than 1 file of potential license (@misak113)
+
 ### v25.0.1 (2019/01/10 19:29 +00:00)
 - [f1c835b](https://github.com/davglass/license-checker/commit/f1c835b991b65dc928eafe64c29b73df9e703169) Updated readme with new args (@davglass)
 - [ada667f](https://github.com/davglass/license-checker/commit/ada667f28e8ef4e96b5b6059fe05541d05ca936c) changelog (@davglass)

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,11 @@ var flatten = function(options) {
             if (!moduleInfo.licenses || moduleInfo.licenses.indexOf(UNKNOWN) > -1 || moduleInfo.licenses.indexOf('Custom:') === 0) {
                 //Only re-check the license if we didn't get it from elsewhere
                 content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
-                moduleInfo.licenses = license(content);
+                var currentLicenses = license(content);
+                // First file has priority. It's usually LICENSE file, second is README
+                if (currentLicenses) {
+                    moduleInfo.licenses = currentLicenses;
+                }
             }
 
             if (index === 0) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "license-checker",
   "description": "Check license info for a package",
   "author": "Dav Glass <davglass@gmail.com>",
-  "version": "25.0.1",
+  "version": "25.0.2",
   "contributors": [
     "Adam Weber <adamweber01@gmail.com>",
     "Andrew Couch <andy@couchand.com>",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "Mattias Amnefelt <mattiasa@cantemo.com>",
     "Michael Kühnel <mail@michael-kuehnel.de>",
     "Michael Williamson <mike@zwobble.org>",
+    "Michael Zabka <zabka.michael@gmail.com>",
     "Paul Mandel <paul.mand3l@gmail.com>",
     "Peter Uithoven <peter@peteruithoven.nl>",
     "Philipp Tusch <philipp.tusch@huf-group.com>",


### PR DESCRIPTION
…license

* in license-files.js is specified correct order of possible files which can be a base for license detection.
* the LICENSE file has priority over e.g. README file. So if the license is detected from earlier file LICENSE, omit detection from other files like a README etc.