### PR TITLE
Add option for failing based on regex comparison against licenses --failOnRegEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-NPM License Checker
-===================
+# NPM License Checker
 
 [![Build Status](https://www.travis-ci.org/davglass/license-checker.svg?branch=master)](https://www.travis-ci.org/davglass/license-checker)
 
-*As of v17.0.0 the `failOn` and `onlyAllow` arguments take semicolons as delimeters instead of commas. Some license names contain
-commas and it messed with the parsing*
+_As of v17.0.0 the `failOn` and `onlyAllow` arguments take semicolons as delimeters instead of commas. Some license names contain
+commas and it messed with the parsing_
 
 Ever needed to see all the license info for a module and its dependencies?
 
@@ -66,31 +65,31 @@ You could see something like this:
    └─ licenses: MIT*
 ```
 
-Options
--------
+## Options
 
-* `--production` only show production dependencies.
-* `--development` only show development dependencies.
-* `--start [path of the initial json to look for]`
-* `--unknown` report guessed licenses as unknown licenses.
-* `--onlyunknown` only list packages with unknown or guessed licenses.
-* `--json` output in json format.
-* `--csv` output in csv format.
-* `--csvComponentPrefix` prefix column for component in csv format.
-* `--out [filepath]` write the data to a specific file.
-* `--customPath` to add a custom Format file in JSON
-* `--exclude [list]` exclude modules which licenses are in the comma-separated list from the output
-* `--relativeLicensePath` output the location of the license files as relative paths
-* `--summary` output a summary of the license usage',
-* `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
-* `--onlyAllow [list]` fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list
-* `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
-* `--excludePackages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
-* `--excludePrivatePackages` restrict output to not include any package marked as private
-* `--direct look for direct dependencies only`
+- `--production` only show production dependencies.
+- `--development` only show development dependencies.
+- `--start [path of the initial json to look for]`
+- `--unknown` report guessed licenses as unknown licenses.
+- `--onlyunknown` only list packages with unknown or guessed licenses.
+- `--json` output in json format.
+- `--csv` output in csv format.
+- `--csvComponentPrefix` prefix column for component in csv format.
+- `--out [filepath]` write the data to a specific file.
+- `--customPath` to add a custom Format file in JSON
+- `--exclude [list]` exclude modules which licenses are in the comma-separated list from the output
+- `--relativeLicensePath` output the location of the license files as relative paths
+- `--summary` output a summary of the license usage',
+- `--failOn [list]` fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
+- `--failOnRegEx [list]` fail (exit with code 1) on the first successful RegEx match of the licenses of the semicolon-seperated list
+- `--onlyAllow [list]` fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list
+- `--packages [list]` restrict output to the packages (package@version) in the semicolon-seperated list
+- `--excludePackages [list]` restrict output to the packages (package@version) not in the semicolon-seperated list
+- `--excludePrivatePackages` restrict output to not include any package marked as private
+- `--direct look for direct dependencies only`
 
-Exclusions
-----------
+## Exclusions
+
 A list of licenses is the simplest way to describe what you want to exclude.
 
 You can use valid [SPDX identifiers](https://spdx.org/licenses/).
@@ -98,8 +97,7 @@ You can use valid SPDX expressions like `MIT OR X11`.
 You can use non-valid SPDX identifiers, like `Public Domain`, since `npm` does
 support some license strings that are not SPDX identifiers.
 
-Examples
---------
+## Examples
 
 ```
 license-checker --json > /path/to/licenses.json
@@ -112,8 +110,7 @@ license-checker --excludePackages 'internal-1;internal-2'
 license-checker --onlyunknown
 ```
 
-Custom format
--------------
+## Custom format
 
 The `--customPath` option can be used with CSV to specify the columns. Note that
 the first column, `module_name`, will always be used.
@@ -121,6 +118,7 @@ the first column, `module_name`, will always be used.
 When used with JSON format, it will add the specified items to the usual ones.
 
 The available items are the following:
+
 - name
 - version
 - description
@@ -136,32 +134,32 @@ The available items are the following:
 You can also give default values for each item.
 See an example in [customFormatExample.json](customFormatExample.json).
 
-Requiring
----------
-
+## Requiring
 
 ```js
-var checker = require('license-checker');
+var checker = require("license-checker");
 
-checker.init({
-    start: '/path/to/start/looking'
-}, function(err, packages) {
+checker.init(
+  {
+    start: "/path/to/start/looking",
+  },
+  function (err, packages) {
     if (err) {
-        //Handle error
+      //Handle error
     } else {
-        //The sorted package data
-        //as an Object
+      //The sorted package data
+      //as an Object
     }
-});
+  }
+);
 ```
 
-Debugging
----------
+## Debugging
 
 license-checker uses [debug](https://www.npmjs.com/package/debug) for internal logging. There’s two internal markers:
 
-* `license-checker:error` for errors
-* `license-checker:log` for non-errors
+- `license-checker:error` for errors
+- `license-checker:log` for non-errors
 
 Set the `DEBUG` environment variable to one of these to see debug output:
 
@@ -174,8 +172,7 @@ scanning ./yui-lint
 # ...
 ```
 
-How Licenses are Found
-----------------------
+## How Licenses are Found
 
 We walk through the `node_modules` directory with the [`read-installed`](https://www.npmjs.org/package/read-installed) module. Once we gathered a list of modules we walk through them and look at all of their `package.json`'s, We try to identify the license with the [`spdx`](https://www.npmjs.com/package/spdx) module to see if it has a valid SPDX license attached. If that fails, we then look into the module for the following files: `LICENSE`, `LICENCE`, `COPYING`, & `README`.
 

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -6,104 +6,115 @@ Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
 
-var checker = require('../lib/index');
+var checker = require("../lib/index");
 
-var args = require('../lib/args').parse();
-var mkdirp = require('mkdirp');
-var path = require('path');
-var chalk = require('chalk');
-var fs = require('fs');
+var args = require("../lib/args").parse();
+var mkdirp = require("mkdirp");
+var path = require("path");
+var chalk = require("chalk");
+var fs = require("fs");
 
 if (args.help) {
-    console.error('license-checker@' + require('../package.json').version);
-    var usage = [
-        '',
-        '   --production only show production dependencies.',
-        '   --development only show development dependencies.',
-        '   --unknown report guessed licenses as unknown licenses.',
-        '   --start [path of the initial json to look for]',
-        '   --onlyunknown only list packages with unknown or guessed licenses.',
-        '   --json output in json format.',
-        '   --csv output in csv format.',
-        '   --csvComponentPrefix column prefix for components in csv file',
-        '   --out [filepath] write the data to a specific file.',
-        '   --customPath to add a custom Format file in JSON',
-        '   --exclude [list] exclude modules which licenses are in the comma-separated list from the output',
-        '   --relativeLicensePath output the location of the license files as relative paths',
-        '   --summary output a summary of the license usage',
-        '   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list',
-        '   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list',
-        '   --direct look for direct dependencies only',
-        '   --packages [list] restrict output to the packages (package@version) in the semicolon-seperated list',
-        '   --excludePackages [list] restrict output to the packages (package@version) not in the semicolon-seperated list',
-        '   --excludePrivatePackages restrict output to not include any package marked as private',
-        '',
-        '   --version The current version',
-        '   --help  The text you are reading right now :)',
-        ''
-    ];
-    console.error(usage.join('\n'), '\n');
-    process.exit(0);
+  console.error("license-checker@" + require("../package.json").version);
+  var usage = [
+    "",
+    "   --production only show production dependencies.",
+    "   --development only show development dependencies.",
+    "   --unknown report guessed licenses as unknown licenses.",
+    "   --start [path of the initial json to look for]",
+    "   --onlyunknown only list packages with unknown or guessed licenses.",
+    "   --json output in json format.",
+    "   --csv output in csv format.",
+    "   --csvComponentPrefix column prefix for components in csv file",
+    "   --out [filepath] write the data to a specific file.",
+    "   --customPath to add a custom Format file in JSON",
+    "   --exclude [list] exclude modules which licenses are in the comma-separated list from the output",
+    "   --relativeLicensePath output the location of the license files as relative paths",
+    "   --summary output a summary of the license usage",
+    "   --failOn [list] fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list",
+    "   --failOnRegEx [list] fail (exit with code 1) on the first successful RegEx match of the licenses of the semicolon-seperated list",
+    "   --onlyAllow [list] fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-seperated list",
+    "   --direct look for direct dependencies only",
+    "   --packages [list] restrict output to the packages (package@version) in the semicolon-seperated list",
+    "   --excludePackages [list] restrict output to the packages (package@version) not in the semicolon-seperated list",
+    "   --excludePrivatePackages restrict output to not include any package marked as private",
+    "",
+    "   --version The current version",
+    "   --help  The text you are reading right now :)",
+    "",
+  ];
+  console.error(usage.join("\n"), "\n");
+  process.exit(0);
 }
 
 if (args.version) {
-    console.error(require('../package.json').version);
-    process.exit(1);
+  console.error(require("../package.json").version);
+  process.exit(1);
 }
 
 if (args.failOn && args.onlyAllow) {
-    console.error('--failOn and --onlyAllow can not be used at the same time. Choose one or the other.');
-    process.exit(1);
+  console.error(
+    "--failOn and --onlyAllow can not be used at the same time. Choose one or the other."
+  );
+  process.exit(1);
 } else {
-    var argValue = args.failOn || args.onlyAllow;
-    if (argValue && argValue.indexOf(',') >= 0) {
-        var argName = args.failOn ? 'failOn' : 'onlyAllow';
-        console.warn('Warning: As of v17 the --' + argName + ' argument takes semicolons as delimeters instead of commas (some license names can contain commas)');
-    }
+  var argValue = args.failOn || args.onlyAllow;
+  if (argValue && argValue.indexOf(",") >= 0) {
+    var argName = args.failOn ? "failOn" : "onlyAllow";
+    console.warn(
+      "Warning: As of v17 the --" +
+        argName +
+        " argument takes semicolons as delimeters instead of commas (some license names can contain commas)"
+    );
+  }
 }
 
-checker.init(args, function(err, json) {
+checker.init(args, function (err, json) {
+  var formattedOutput = "";
 
-    var formattedOutput = '';
+  if (!!err) {
+    console.error("Found error");
+    console.error(err);
+  }
 
-    if (!!err) {
-        console.error('Found error');
-        console.error(err);
-    }
+  if (shouldColorizeOutput(args)) {
+    var keys = Object.keys(json);
+    keys.forEach(function (key) {
+      var keyParts = key.split("@");
+      var colorizedKey =
+        chalk.blue(keyParts[0]) + chalk.dim("@") + chalk.green(keyParts[1]);
+      json[colorizedKey] = json[key];
+      delete json[key];
+    });
+  }
 
-    if (shouldColorizeOutput(args)) {
-        var keys = Object.keys(json);
-        keys.forEach(function(key) {
-            var keyParts = key.split('@');
-            var colorizedKey = chalk.blue(keyParts[0]) + chalk.dim('@') + chalk.green(keyParts[1]);
-            json[colorizedKey] = json[key];
-            delete json[key];
-        });
-    }
+  if (args.json) {
+    formattedOutput = JSON.stringify(json, null, 2) + "\n";
+  } else if (args.csv) {
+    formattedOutput = checker.asCSV(
+      json,
+      args.customFormat,
+      args.csvComponentPrefix
+    );
+  } else if (args.markdown) {
+    formattedOutput = checker.asMarkDown(json, args.customFormat) + "\n";
+  } else if (args.summary) {
+    formattedOutput = checker.asSummary(json);
+  } else {
+    formattedOutput = checker.asTree(json);
+  }
 
-    if (args.json) {
-        formattedOutput = JSON.stringify(json, null, 2) + '\n';
-    } else if (args.csv) {
-        formattedOutput = checker.asCSV(json, args.customFormat, args.csvComponentPrefix);
-    } else if (args.markdown){
-        formattedOutput = checker.asMarkDown(json, args.customFormat) + '\n';
-    } else if (args.summary) {
-        formattedOutput = checker.asSummary(json);
-    } else {
-        formattedOutput = checker.asTree(json);
-    }
-
-    if (args.files) {
-        checker.asFiles(json, args.files);
-    } else if (args.out) {
-        var dir = path.dirname(args.out);
-        mkdirp.sync(dir);
-        fs.writeFileSync(args.out, formattedOutput, 'utf8');
-    } else {
-        console.log(formattedOutput);
-    }
+  if (args.files) {
+    checker.asFiles(json, args.files);
+  } else if (args.out) {
+    var dir = path.dirname(args.out);
+    mkdirp.sync(dir);
+    fs.writeFileSync(args.out, formattedOutput, "utf8");
+  } else {
+    console.log(formattedOutput);
+  }
 });
 
 function shouldColorizeOutput(args) {
-    return args.color && !args.out && !(args.csv || args.json || args.markdown);
+  return args.color && !args.out && !(args.csv || args.json || args.markdown);
 }

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -52,9 +52,9 @@ if (args.version) {
   process.exit(1);
 }
 
-if (args.failOn && args.onlyAllow) {
+if ((args.failOn || args.failOnRegEx) && args.onlyAllow) {
   console.error(
-    "--failOn and --onlyAllow can not be used at the same time. Choose one or the other."
+    "--failOn and --failOnRegEx can not be used at the same time as --onlyAllow. Choose one or the other."
   );
   process.exit(1);
 } else {

--- a/lib/args.js
+++ b/lib/args.js
@@ -5,90 +5,90 @@ http://yuilibrary.com/license/
 */
 
 var nopt = require("nopt"),
-  chalk = require("chalk"),
-  known = {
-    production: Boolean,
-    development: Boolean,
-    json: Boolean,
-    csv: Boolean,
-    csvComponentPrefix: String,
-    markdown: Boolean,
-    out: require("path"),
-    unknown: Boolean,
-    onlyunknown: Boolean,
-    version: Boolean,
-    color: Boolean,
-    start: String,
-    help: Boolean,
-    relativeLicensePath: Boolean,
-    exclude: String,
-    customPath: require("path"),
-    customFormat: {},
-    files: require("path"),
-    summary: Boolean,
-    failOn: String,
-    failOnRegEx: String,
-    onlyAllow: String,
-    direct: Boolean,
-    packages: String,
-    excludePackages: String,
-    excludePrivatePackages: Boolean,
-  },
-  shorts = {
-    v: ["--version"],
-    h: ["--help"],
-  };
+    chalk = require("chalk"),
+    known = {
+        production: Boolean,
+        development: Boolean,
+        json: Boolean,
+        csv: Boolean,
+        csvComponentPrefix: String,
+        markdown: Boolean,
+        out: require("path"),
+        unknown: Boolean,
+        onlyunknown: Boolean,
+        version: Boolean,
+        color: Boolean,
+        start: String,
+        help: Boolean,
+        relativeLicensePath: Boolean,
+        exclude: String,
+        customPath: require("path"),
+        customFormat: {},
+        files: require("path"),
+        summary: Boolean,
+        failOn: String,
+        failOnRegEx: String,
+        onlyAllow: String,
+        direct: Boolean,
+        packages: String,
+        excludePackages: String,
+        excludePrivatePackages: Boolean,
+    },
+    shorts = {
+        v: ["--version"],
+        h: ["--help"],
+    };
 
-var raw = function (args) {
-  return nopt(known, shorts, args || process.argv);
+var raw = function(args) {
+    return nopt(known, shorts, args || process.argv);
 };
 
 /*istanbul ignore next */
-var has = function (a) {
-  var cooked = raw().argv.cooked,
-    ret = false;
+var has = function(a) {
+    var cooked = raw().argv.cooked,
+        ret = false;
 
-  cooked.forEach(function (o) {
-    if (o === "--" + a || o === "--no-" + a) {
-      ret = true;
+    cooked.forEach(function(o) {
+        if (o === "--" + a || o === "--no-" + a) {
+            ret = true;
+        }
+    });
+
+    return ret;
+};
+
+var clean = function(args) {
+    var parsed = raw(args);
+    delete parsed.argv;
+    return parsed;
+};
+
+var setDefaults = function(parsed) {
+    if (parsed === undefined) {
+        parsed = clean();
     }
-  });
+    /*istanbul ignore else*/
+    if (parsed.color === undefined) {
+        parsed.color = chalk.supportsColor;
+    }
+    if (parsed.json || parsed.markdown || parsed.csv) {
+        parsed.color = false;
+    }
+    parsed.start = parsed.start || process.cwd();
+    parsed.relativeLicensePath = !!parsed.relativeLicensePath;
 
-  return ret;
+    if (parsed.direct) {
+        parsed.direct = 0;
+    } else {
+        parsed.direct = Infinity;
+    }
+
+    return parsed;
 };
 
-var clean = function (args) {
-  var parsed = raw(args);
-  delete parsed.argv;
-  return parsed;
-};
-
-var setDefaults = function (parsed) {
-  if (parsed === undefined) {
-    parsed = clean();
-  }
-  /*istanbul ignore else*/
-  if (parsed.color === undefined) {
-    parsed.color = chalk.supportsColor;
-  }
-  if (parsed.json || parsed.markdown || parsed.csv) {
-    parsed.color = false;
-  }
-  parsed.start = parsed.start || process.cwd();
-  parsed.relativeLicensePath = !!parsed.relativeLicensePath;
-
-  if (parsed.direct) {
-    parsed.direct = 0;
-  } else {
-    parsed.direct = Infinity;
-  }
-
-  return parsed;
-};
-
-var parse = function (args) {
-  var parsed = clean(args);
-  return setDefaults(parsed);
+var parse = function(args) {
+    var parsed = clean(args);
+    return setDefaults(parsed);
 };
 
 exports.defaults = setDefaults;

--- a/lib/args.js
+++ b/lib/args.js
@@ -4,90 +4,91 @@ Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
 
-var nopt = require('nopt'),
-    chalk = require('chalk'),
-    known = {
-        production: Boolean,
-        development: Boolean,
-        json: Boolean,
-        csv: Boolean,
-        csvComponentPrefix: String,
-        markdown: Boolean,
-        out: require('path'),
-        unknown: Boolean,
-        onlyunknown: Boolean,
-        version: Boolean,
-        color: Boolean,
-        start: String,
-        help: Boolean,
-        relativeLicensePath: Boolean,
-        exclude: String,
-        customPath: require('path'),
-        customFormat: { },
-        files: require('path'),
-        summary: Boolean,
-        failOn: String,
-        onlyAllow: String,
-        direct: Boolean,
-        packages: String,
-        excludePackages: String,
-        excludePrivatePackages: Boolean,
-    },
-    shorts = {
-        "v": ["--version"],
-        "h": ["--help"]
-    };
+var nopt = require("nopt"),
+  chalk = require("chalk"),
+  known = {
+    production: Boolean,
+    development: Boolean,
+    json: Boolean,
+    csv: Boolean,
+    csvComponentPrefix: String,
+    markdown: Boolean,
+    out: require("path"),
+    unknown: Boolean,
+    onlyunknown: Boolean,
+    version: Boolean,
+    color: Boolean,
+    start: String,
+    help: Boolean,
+    relativeLicensePath: Boolean,
+    exclude: String,
+    customPath: require("path"),
+    customFormat: {},
+    files: require("path"),
+    summary: Boolean,
+    failOn: String,
+    failOnRegEx: String,
+    onlyAllow: String,
+    direct: Boolean,
+    packages: String,
+    excludePackages: String,
+    excludePrivatePackages: Boolean,
+  },
+  shorts = {
+    v: ["--version"],
+    h: ["--help"],
+  };
 
-var raw = function(args) {
-    return nopt(known, shorts, (args || process.argv));
+var raw = function (args) {
+  return nopt(known, shorts, args || process.argv);
 };
 
 /*istanbul ignore next */
-var has = function(a) {
-    var cooked = raw().argv.cooked,
-        ret = false;
+var has = function (a) {
+  var cooked = raw().argv.cooked,
+    ret = false;
 
-    cooked.forEach(function(o) {
-        if ((o === '--' + a) || (o === '--no-' + a)) {
-            ret = true;
-        }
-    });
+  cooked.forEach(function (o) {
+    if (o === "--" + a || o === "--no-" + a) {
+      ret = true;
+    }
+  });
 
-    return ret;
+  return ret;
 };
 
-var clean = function(args) {
-    var parsed = raw(args);
-    delete parsed.argv;
-    return parsed;
+var clean = function (args) {
+  var parsed = raw(args);
+  delete parsed.argv;
+  return parsed;
 };
 
-var setDefaults = function(parsed) {
-    if (parsed === undefined) {
-        parsed = clean();
-    }
-    /*istanbul ignore else*/
-    if (parsed.color === undefined) {
-        parsed.color = chalk.supportsColor;
-    }
-    if (parsed.json || parsed.markdown || parsed.csv) {
-        parsed.color = false;
-    }
-    parsed.start = parsed.start || process.cwd();
-    parsed.relativeLicensePath = !!parsed.relativeLicensePath;
+var setDefaults = function (parsed) {
+  if (parsed === undefined) {
+    parsed = clean();
+  }
+  /*istanbul ignore else*/
+  if (parsed.color === undefined) {
+    parsed.color = chalk.supportsColor;
+  }
+  if (parsed.json || parsed.markdown || parsed.csv) {
+    parsed.color = false;
+  }
+  parsed.start = parsed.start || process.cwd();
+  parsed.relativeLicensePath = !!parsed.relativeLicensePath;
 
-    if (parsed.direct) {
-        parsed.direct = 0;
-    } else {
-        parsed.direct = Infinity;
-    }
+  if (parsed.direct) {
+    parsed.direct = 0;
+  } else {
+    parsed.direct = Infinity;
+  }
 
-    return parsed;
+  return parsed;
 };
 
-var parse = function(args) {
-    var parsed = clean(args);
-    return setDefaults(parsed);
+var parse = function (args) {
+  var parsed = clean(args);
+  return setDefaults(parsed);
 };
 
 exports.defaults = setDefaults;

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,640 +24,654 @@ var debugError = debug("license-checker:error");
 var debugLog = debug("license-checker:log");
 debugLog.log = console.log.bind(console);
 
-var flatten = function (options) {
-  var moduleInfo = { licenses: UNKNOWN },
-    json = options.deps,
-    data = options.data,
-    key = json.name + "@" + json.version,
-    colorize = options.color,
-    unknown = options.unknown,
-    readmeFile,
-    licenseData,
-    dirFiles,
-    files = [],
-    noticeFiles = [],
-    licenseFile;
+var flatten = function(options) {
+    var moduleInfo = { licenses: UNKNOWN },
+        json = options.deps,
+        data = options.data,
+        key = json.name + "@" + json.version,
+        colorize = options.color,
+        unknown = options.unknown,
+        readmeFile,
+        licenseData,
+        dirFiles,
+        files = [],
+        noticeFiles = [],
+        licenseFile;
 
-  if (json.private) {
-    moduleInfo.private = true;
-  }
-
-  // If we have processed this key already, just return the data object.
-  // This was added so that we don't recurse forever if there was a circular
-  // dependency in the dependency tree.
-  /*istanbul ignore next*/
-  if (data[key]) {
-    return data;
-  }
-
-  if (
-    (options.production && json.extraneous) ||
-    (options.development && !json.extraneous && !json.root)
-  ) {
-    return data;
-  }
-
-  data[key] = moduleInfo;
-
-  // Include property in output unless custom format has set property to false.
-  var include = function (property) {
-    return (
-      options.customFormat === undefined ||
-      options.customFormat[property] !== false
-    );
-  };
-
-  if (include("repository") && json.repository) {
-    /*istanbul ignore else*/
-    if (
-      typeof json.repository === "object" &&
-      typeof json.repository.url === "string"
-    ) {
-      moduleInfo.repository = json.repository.url.replace(
-        "git+ssh://git@",
-        "git://"
-      );
-      moduleInfo.repository = moduleInfo.repository.replace(
-        "git+https://github.com",
-        "https://github.com"
-      );
-      moduleInfo.repository = moduleInfo.repository.replace(
-        "git://github.com",
-        "https://github.com"
-      );
-      moduleInfo.repository = moduleInfo.repository.replace(
-        "git@github.com:",
-        "https://github.com/"
-      );
-      moduleInfo.repository = moduleInfo.repository.replace(/\.git$/, "");
+    if (json.private) {
+        moduleInfo.private = true;
     }
-  }
-  if (include("url") && json.url) {
+
+    // If we have processed this key already, just return the data object.
+    // This was added so that we don't recurse forever if there was a circular
+    // dependency in the dependency tree.
     /*istanbul ignore next*/
-    if (typeof json.url === "object") {
-      moduleInfo.url = json.url.web;
+    if (data[key]) {
+        return data;
     }
-  }
-  if (json.author && typeof json.author === "object") {
-    /*istanbul ignore else - This should always be there*/
-    if (include("publisher") && json.author.name) {
-      moduleInfo.publisher = json.author.name;
-    }
-    if (include("email") && json.author.email) {
-      moduleInfo.email = json.author.email;
-    }
-    if (include("url") && json.author.url) {
-      moduleInfo.url = json.author.url;
-    }
-  }
 
-  /*istanbul ignore next*/
-  if (unknown) {
-    moduleInfo.dependencyPath = json.path;
-  }
-
-  /*istanbul ignore next*/
-  if (options.customFormat) {
-    Object.keys(options.customFormat).forEach(function forEachCallback(item) {
-      if (include(item) && json[item]) {
-        //For now, we only support strings, not JSON objects
-        if (typeof json[item] === "string") {
-          moduleInfo[item] = json[item];
-        }
-      } else if (include(item)) {
-        moduleInfo[item] = options.customFormat[item];
-      }
-    });
-  }
-
-  if (include("path") && json.path && typeof json.path === "string") {
-    moduleInfo.path = json.path;
-  }
-
-  licenseData = json.license || json.licenses || undefined;
-
-  if (
-    json.path &&
-    (!json.readme ||
-      json.readme.toLowerCase().indexOf("no readme data found") > -1)
-  ) {
-    readmeFile = path.join(json.path, "README.md");
-    /*istanbul ignore if*/
-    if (fs.existsSync(readmeFile)) {
-      json.readme = fs.readFileSync(readmeFile, "utf8").toString();
-    }
-  }
-
-  if (licenseData) {
-    /*istanbul ignore else*/
-    if (Array.isArray(licenseData) && licenseData.length > 0) {
-      moduleInfo.licenses = licenseData.map(function (license) {
-        /*istanbul ignore else*/
-        if (typeof license === "object") {
-          /*istanbul ignore next*/
-          return license.type || license.name;
-        } else if (typeof license === "string") {
-          return license;
-        }
-      });
-    } else if (
-      typeof licenseData === "object" &&
-      (licenseData.type || licenseData.name)
+    if (
+        (options.production && json.extraneous) ||
+    (options.development && !json.extraneous && !json.root)
     ) {
-      moduleInfo.licenses = license(licenseData.type || licenseData.name);
-    } else if (typeof licenseData === "string") {
-      moduleInfo.licenses = license(licenseData);
+        return data;
     }
-  } else if (license(json.readme)) {
-    moduleInfo.licenses = license(json.readme);
-  }
 
-  if (Array.isArray(moduleInfo.licenses)) {
-    /*istanbul ignore else*/
-    if (moduleInfo.licenses.length === 1) {
-      moduleInfo.licenses = moduleInfo.licenses[0];
-    }
-  }
+    data[key] = moduleInfo;
 
-  /*istanbul ignore else*/
-  if (json.path && fs.existsSync(json.path)) {
-    dirFiles = fs.readdirSync(json.path);
-    files = licenseFiles(dirFiles);
-
-    noticeFiles = dirFiles.filter(function (filename) {
-      filename = filename.toUpperCase();
-      var name = path.basename(filename).replace(path.extname(filename), "");
-      return name === "NOTICE";
-    });
-  }
-
-  files.forEach(function (filename, index) {
-    licenseFile = path.join(json.path, filename);
-    // Checking that the file is in fact a normal file and not a directory for example.
-    /*istanbul ignore else*/
-    if (fs.lstatSync(licenseFile).isFile()) {
-      var content;
-      if (
-        !moduleInfo.licenses ||
-        moduleInfo.licenses.indexOf(UNKNOWN) > -1 ||
-        moduleInfo.licenses.indexOf("Custom:") === 0
-      ) {
-        //Only re-check the license if we didn't get it from elsewhere
-        content = fs.readFileSync(licenseFile, { encoding: "utf8" });
-        moduleInfo.licenses = license(content);
-      }
-
-      if (index === 0) {
-        // Treat the file with the highest precedence as licenseFile
-        /*istanbul ignore else*/
-        if (include("licenseFile")) {
-          moduleInfo.licenseFile = options.basePath
-            ? path.relative(options.basePath, licenseFile)
-            : licenseFile;
-        }
-
-        if (include("licenseText") && options.customFormat) {
-          if (!content) {
-            content = fs.readFileSync(licenseFile, { encoding: "utf8" });
-          }
-          /*istanbul ignore else*/
-          if (options._args && !options._args.csv) {
-            moduleInfo.licenseText = content.trim();
-          } else {
-            moduleInfo.licenseText = content
-              .replace(/"/g, "'")
-              .replace(/\r?\n|\r/g, " ")
-              .trim();
-          }
-        }
-
-        if (include("copyright") && options.customFormat) {
-          if (!content) {
-            content = fs.readFileSync(licenseFile, { encoding: "utf8" });
-          }
-
-          var linesWithCopyright = content
-            .replace(/\r\n/g, "\n")
-            .split("\n\n")
-            .filter(function selectCopyRightStatements(value) {
-              return (
-                value.startsWith("opyright", 1) && // include copyright statements
-                !value.startsWith("opyright notice", 1) && // exclude lines from from license text
-                !value.startsWith("opyright and related rights", 1)
-              );
-            })
-            .filter(function removeDuplicates(value, index, list) {
-              return index === 0 || value !== list[0];
-            });
-
-          if (linesWithCopyright.length > 0) {
-            moduleInfo.copyright = linesWithCopyright[0]
-              .replace(/\n/g, ". ")
-              .trim();
-          }
-
-          // Mark files with multiple copyright statements. This might be
-          // an indicator to take a closer look at the LICENSE file.
-          if (linesWithCopyright.length > 1) {
-            moduleInfo.copyright += "*";
-          }
-        }
-      }
-    }
-  });
-
-  noticeFiles.forEach(function (filename) {
-    var file = path.join(json.path, filename);
-    /*istanbul ignore else*/
-    if (fs.lstatSync(file).isFile()) {
-      moduleInfo.noticeFile = options.basePath
-        ? path.relative(options.basePath, file)
-        : file;
-    }
-  });
-
-  /*istanbul ignore else*/
-  if (json.dependencies) {
-    Object.keys(json.dependencies).forEach(function (name) {
-      var childDependency = json.dependencies[name],
-        dependencyId = childDependency.name + "@" + childDependency.version;
-      if (data[dependencyId]) {
-        // already exists
-        return;
-      }
-      data = flatten({
-        deps: childDependency,
-        data: data,
-        color: colorize,
-        unknown: unknown,
-        customFormat: options.customFormat,
-        production: options.production,
-        development: options.development,
-        basePath: options.basePath,
-        _args: options._args,
-      });
-    });
-  }
-  if (!json.name || !json.version) {
-    delete data[key];
-  }
-  return data;
-};
-
-exports.init = function (options, callback) {
-  debugLog("scanning %s", options.start);
-
-  if (options.customPath) {
-    options.customFormat = this.parseJson(options.customPath);
-  }
-  var opts = {
-    dev: true,
-    log: debugLog,
-    depth: options.direct,
-  };
-
-  if (options.production || options.development) {
-    opts.dev = false;
-  }
-
-  var toCheckforFailOn = [];
-  var toCheckforOnlyAllow = [];
-  var checker, pusher;
-  if (options.onlyAllow) {
-    checker = options.onlyAllow;
-    pusher = toCheckforOnlyAllow;
-  }
-  if (options.failOn || options.failOnRegEx) {
-    checker = options.failOn || options.failOnRegEx;
-    pusher = toCheckforFailOn;
-  }
-  if (checker && pusher) {
-    checker.split(";").forEach(function (license) {
-      var trimmed = license.trim();
-      /*istanbul ignore else*/
-      if (trimmed.length > 0) {
-        pusher.push(trimmed);
-      }
-    });
-  }
-
-  read(options.start, opts, function (err, json) {
-    var data = flatten({
-        deps: json,
-        data: {},
-        color: options.color,
-        unknown: options.unknown,
-        customFormat: options.customFormat,
-        production: options.production,
-        development: options.development,
-        basePath: options.relativeLicensePath ? json.path : null,
-        _args: options,
-      }),
-      colorize = options.color,
-      sorted = {},
-      filtered = {},
-      exclude =
-        options.exclude &&
-        options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function (license) {
-          return license.replace(/\\,/g, ",").replace(/^\s+|\s+$/g, "");
-        }),
-      inputError = null;
-
-    var colorizeString = function (string) {
-      /*istanbul ignore next*/
-      return colorize ? chalk.bold.red(string) : string;
+    // Include property in output unless custom format has set property to false.
+    var include = function(property) {
+        return (
+            options.customFormat === undefined ||
+      options.customFormat[property] !== false
+        );
     };
 
-    Object.keys(data)
-      .sort()
-      .forEach(function (item) {
-        if (data[item].private) {
-          data[item].licenses = colorizeString(UNLICENSED);
+    if (include("repository") && json.repository) {
+    /*istanbul ignore else*/
+        if (
+            typeof json.repository === "object" &&
+      typeof json.repository.url === "string"
+        ) {
+            moduleInfo.repository = json.repository.url.replace(
+                "git+ssh://git@",
+                "git://"
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(
+                "git+https://github.com",
+                "https://github.com"
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(
+                "git://github.com",
+                "https://github.com"
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(
+                "git@github.com:",
+                "https://github.com/"
+            );
+            moduleInfo.repository = moduleInfo.repository.replace(/\.git$/, "");
         }
-        /*istanbul ignore next*/
-        if (!data[item].licenses) {
-          data[item].licenses = colorizeString(UNKNOWN);
+    }
+    if (include("url") && json.url) {
+    /*istanbul ignore next*/
+        if (typeof json.url === "object") {
+            moduleInfo.url = json.url.web;
         }
-        if (options.unknown) {
-          /*istanbul ignore else*/
-          if (data[item].licenses && data[item].licenses !== UNKNOWN) {
-            if (data[item].licenses.indexOf("*") > -1) {
-              /*istanbul ignore if*/
-              data[item].licenses = colorizeString(UNKNOWN);
+    }
+    if (json.author && typeof json.author === "object") {
+    /*istanbul ignore else - This should always be there*/
+        if (include("publisher") && json.author.name) {
+            moduleInfo.publisher = json.author.name;
+        }
+        if (include("email") && json.author.email) {
+            moduleInfo.email = json.author.email;
+        }
+        if (include("url") && json.author.url) {
+            moduleInfo.url = json.author.url;
+        }
+    }
+
+    /*istanbul ignore next*/
+    if (unknown) {
+        moduleInfo.dependencyPath = json.path;
+    }
+
+    /*istanbul ignore next*/
+    if (options.customFormat) {
+        Object.keys(options.customFormat).forEach(function forEachCallback(item) {
+            if (include(item) && json[item]) {
+                //For now, we only support strings, not JSON objects
+                if (typeof json[item] === "string") {
+                    moduleInfo[item] = json[item];
+                }
+            } else if (include(item)) {
+                moduleInfo[item] = options.customFormat[item];
             }
-          }
+        });
+    }
+
+    if (include("path") && json.path && typeof json.path === "string") {
+        moduleInfo.path = json.path;
+    }
+
+    licenseData = json.license || json.licenses || undefined;
+
+    if (
+        json.path &&
+    (!json.readme ||
+      json.readme.toLowerCase().indexOf("no readme data found") > -1)
+    ) {
+        readmeFile = path.join(json.path, "README.md");
+        /*istanbul ignore if*/
+        if (fs.existsSync(readmeFile)) {
+            json.readme = fs.readFileSync(readmeFile, "utf8").toString();
         }
+    }
+
+    if (licenseData) {
+    /*istanbul ignore else*/
+        if (Array.isArray(licenseData) && licenseData.length > 0) {
+            moduleInfo.licenses = licenseData.map(function(license) {
+                /*istanbul ignore else*/
+                if (typeof license === "object") {
+                    /*istanbul ignore next*/
+                    return license.type || license.name;
+                } else if (typeof license === "string") {
+                    return license;
+                }
+            });
+        } else if (
+            typeof licenseData === "object" &&
+      (licenseData.type || licenseData.name)
+        ) {
+            moduleInfo.licenses = license(licenseData.type || licenseData.name);
+        } else if (typeof licenseData === "string") {
+            moduleInfo.licenses = license(licenseData);
+        }
+    } else if (license(json.readme)) {
+        moduleInfo.licenses = license(json.readme);
+    }
+
+    if (Array.isArray(moduleInfo.licenses)) {
+    /*istanbul ignore else*/
+        if (moduleInfo.licenses.length === 1) {
+            moduleInfo.licenses = moduleInfo.licenses[0];
+        }
+    }
+
+    /*istanbul ignore else*/
+    if (json.path && fs.existsSync(json.path)) {
+        dirFiles = fs.readdirSync(json.path);
+        files = licenseFiles(dirFiles);
+
+        noticeFiles = dirFiles.filter(function(filename) {
+            filename = filename.toUpperCase();
+            var name = path.basename(filename).replace(path.extname(filename), "");
+            return name === "NOTICE";
+        });
+    }
+
+    files.forEach(function(filename, index) {
+        licenseFile = path.join(json.path, filename);
+        // Checking that the file is in fact a normal file and not a directory for example.
         /*istanbul ignore else*/
-        if (data[item]) {
-          if (options.onlyunknown) {
+        if (fs.lstatSync(licenseFile).isFile()) {
+            var content;
             if (
-              data[item].licenses.indexOf("*") > -1 ||
-              data[item].licenses.indexOf(UNKNOWN) > -1
+                !moduleInfo.licenses ||
+        moduleInfo.licenses.indexOf(UNKNOWN) > -1 ||
+        moduleInfo.licenses.indexOf("Custom:") === 0
             ) {
-              sorted[item] = data[item];
+                //Only re-check the license if we didn't get it from elsewhere
+                content = fs.readFileSync(licenseFile, { encoding: "utf8" });
+                moduleInfo.licenses = license(content);
             }
-          } else {
-            sorted[item] = data[item];
-          }
-        }
-      });
 
-    if (!Object.keys(sorted).length) {
-      err = new Error("No packages found in this path..");
+            if (index === 0) {
+                // Treat the file with the highest precedence as licenseFile
+                /*istanbul ignore else*/
+                if (include("licenseFile")) {
+                    moduleInfo.licenseFile = options.basePath
+                        ? path.relative(options.basePath, licenseFile)
+                        : licenseFile;
+                }
+
+                if (include("licenseText") && options.customFormat) {
+                    if (!content) {
+                        content = fs.readFileSync(licenseFile, { encoding: "utf8" });
+                    }
+                    /*istanbul ignore else*/
+                    if (options._args && !options._args.csv) {
+                        moduleInfo.licenseText = content.trim();
+                    } else {
+                        moduleInfo.licenseText = content
+                            .replace(/"/g, "'")
+                            .replace(/\r?\n|\r/g, " ")
+                            .trim();
+                    }
+                }
+
+                if (include("copyright") && options.customFormat) {
+                    if (!content) {
+                        content = fs.readFileSync(licenseFile, { encoding: "utf8" });
+                    }
+
+                    var linesWithCopyright = content
+                        .replace(/\r\n/g, "\n")
+                        .split("\n\n")
+                        .filter(function selectCopyRightStatements(value) {
+                            return (
+                                value.startsWith("opyright", 1) && // include copyright statements
+                !value.startsWith("opyright notice", 1) && // exclude lines from from license text
+                !value.startsWith("opyright and related rights", 1)
+                            );
+                        })
+                        .filter(function removeDuplicates(value, index, list) {
+                            return index === 0 || value !== list[0];
+                        });
+
+                    if (linesWithCopyright.length > 0) {
+                        moduleInfo.copyright = linesWithCopyright[0]
+                            .replace(/\n/g, ". ")
+                            .trim();
+                    }
+
+                    // Mark files with multiple copyright statements. This might be
+                    // an indicator to take a closer look at the LICENSE file.
+                    if (linesWithCopyright.length > 1) {
+                        moduleInfo.copyright += "*";
+                    }
+                }
+            }
+        }
+    });
+
+    noticeFiles.forEach(function(filename) {
+        var file = path.join(json.path, filename);
+        /*istanbul ignore else*/
+        if (fs.lstatSync(file).isFile()) {
+            moduleInfo.noticeFile = options.basePath
+                ? path.relative(options.basePath, file)
+                : file;
+        }
+    });
+
+    /*istanbul ignore else*/
+    if (json.dependencies) {
+        Object.keys(json.dependencies).forEach(function(name) {
+            var childDependency = json.dependencies[name],
+                dependencyId = childDependency.name + "@" + childDependency.version;
+            if (data[dependencyId]) {
+                // already exists
+                return;
+            }
+            data = flatten({
+                deps: childDependency,
+                data: data,
+                color: colorize,
+                unknown: unknown,
+                customFormat: options.customFormat,
+                production: options.production,
+                development: options.development,
+                basePath: options.basePath,
+                _args: options._args,
+            });
+        });
+    }
+    if (!json.name || !json.version) {
+        delete data[key];
+    }
+    return data;
+};
+
+exports.init = function(options, callback) {
+    debugLog("scanning %s", options.start);
+
+    if (options.customPath) {
+        options.customFormat = this.parseJson(options.customPath);
+    }
+    var opts = {
+        dev: true,
+        log: debugLog,
+        depth: options.direct,
+    };
+
+    if (options.production || options.development) {
+        opts.dev = false;
     }
 
-    if (exclude) {
-      var transformBSD = function (spdx) {
-        return spdx === "BSD"
-          ? "(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)"
-          : spdx;
-      };
-      var invert = function (fn) {
-        return function (spdx) {
-          return !fn(spdx);
+    var toCheckforFailOn = [];
+    var toCheckforFailOnRegEx = [];
+    var toCheckforOnlyAllow = [];
+    var checker, pusher, checkerReg, pusherReg;
+    if (options.onlyAllow) {
+        checker = options.onlyAllow;
+        pusher = toCheckforOnlyAllow;
+    }
+    if (options.failOn) {
+        checker = options.failOn;
+        pusher = toCheckforFailOn;
+    }
+    if (options.failOnRegEx) {
+        checkerReg = options.failOnRegEx;
+        pusherReg = toCheckforFailOnRegEx;
+    }
+    if (checker && pusher) {
+        checker.split(";").forEach(function(license) {
+            var trimmed = license.trim();
+            /*istanbul ignore else*/
+            if (trimmed.length > 0) {
+                pusher.push(trimmed);
+            }
+        });
+    }
+    if (checkerReg && pusherReg) {
+        checkerReg.split(";").forEach(function(license) {
+            var trimmed = license.trim();
+            /*istanbul ignore else*/
+            if (trimmed.length > 0) {
+                pusherReg.push(trimmed);
+            }
+        });
+    }
+
+    read(options.start, opts, function(err, json) {
+        var data = flatten({
+                deps: json,
+                data: {},
+                color: options.color,
+                unknown: options.unknown,
+                customFormat: options.customFormat,
+                production: options.production,
+                development: options.development,
+                basePath: options.relativeLicensePath ? json.path : null,
+                _args: options,
+            }),
+            colorize = options.color,
+            sorted = {},
+            filtered = {},
+            exclude =
+        options.exclude &&
+        options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
+            return license.replace(/\\,/g, ",").replace(/^\s+|\s+$/g, "");
+        }),
+            inputError = null;
+
+        var colorizeString = function(string) {
+            /*istanbul ignore next*/
+            return colorize ? chalk.bold.red(string) : string;
         };
-      };
-      var spdxIsValid = function (spdx) {
-        return spdxCorrect(spdx) === spdx;
-      };
 
-      var validSPDXLicenses = exclude.map(transformBSD).filter(spdxIsValid);
-      var invalidSPDXLicenses = exclude
-        .map(transformBSD)
-        .filter(invert(spdxIsValid));
-      var spdxExcluder = "( " + validSPDXLicenses.join(" OR ") + " )";
+        Object.keys(data)
+            .sort()
+            .forEach(function(item) {
+                if (data[item].private) {
+                    data[item].licenses = colorizeString(UNLICENSED);
+                }
+                /*istanbul ignore next*/
+                if (!data[item].licenses) {
+                    data[item].licenses = colorizeString(UNKNOWN);
+                }
+                if (options.unknown) {
+                    /*istanbul ignore else*/
+                    if (data[item].licenses && data[item].licenses !== UNKNOWN) {
+                        if (data[item].licenses.indexOf("*") > -1) {
+                            /*istanbul ignore if*/
+                            data[item].licenses = colorizeString(UNKNOWN);
+                        }
+                    }
+                }
+                /*istanbul ignore else*/
+                if (data[item]) {
+                    if (options.onlyunknown) {
+                        if (
+                            data[item].licenses.indexOf("*") > -1 ||
+              data[item].licenses.indexOf(UNKNOWN) > -1
+                        ) {
+                            sorted[item] = data[item];
+                        }
+                    } else {
+                        sorted[item] = data[item];
+                    }
+                }
+            });
 
-      Object.keys(sorted).forEach(function (item) {
-        var licenses = sorted[item].licenses;
-        /*istanbul ignore if - just for protection*/
-        if (!licenses) {
-          filtered[item] = sorted[item];
-        } else {
-          licenses = [].concat(licenses);
-          var licenseMatch = false;
-          licenses.forEach(function (license) {
-            /*istanbul ignore if - just for protection*/
-            if (license.indexOf(UNKNOWN) >= 0) {
-              // necessary due to colorization
-              filtered[item] = sorted[item];
-            } else {
-              if (license.indexOf("*") >= 0) {
-                license = license.substring(0, license.length - 1);
-              }
-              if (license === "BSD") {
-                license =
+        if (!Object.keys(sorted).length) {
+            err = new Error("No packages found in this path..");
+        }
+
+        if (exclude) {
+            var transformBSD = function(spdx) {
+                return spdx === "BSD"
+                    ? "(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)"
+                    : spdx;
+            };
+            var invert = function(fn) {
+                return function(spdx) {
+                    return !fn(spdx);
+                };
+            };
+            var spdxIsValid = function(spdx) {
+                return spdxCorrect(spdx) === spdx;
+            };
+
+            var validSPDXLicenses = exclude.map(transformBSD).filter(spdxIsValid);
+            var invalidSPDXLicenses = exclude
+                .map(transformBSD)
+                .filter(invert(spdxIsValid));
+            var spdxExcluder = "( " + validSPDXLicenses.join(" OR ") + " )";
+
+            Object.keys(sorted).forEach(function(item) {
+                var licenses = sorted[item].licenses;
+                /*istanbul ignore if - just for protection*/
+                if (!licenses) {
+                    filtered[item] = sorted[item];
+                } else {
+                    licenses = [].concat(licenses);
+                    var licenseMatch = false;
+                    licenses.forEach(function(license) {
+                        /*istanbul ignore if - just for protection*/
+                        if (license.indexOf(UNKNOWN) >= 0) {
+                            // necessary due to colorization
+                            filtered[item] = sorted[item];
+                        } else {
+                            if (license.indexOf("*") >= 0) {
+                                license = license.substring(0, license.length - 1);
+                            }
+                            if (license === "BSD") {
+                                license =
                   "(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)";
-              }
+                            }
 
-              if (invalidSPDXLicenses.indexOf(license) >= 0) {
-                licenseMatch = true;
-              } else if (
-                spdxCorrect(license) &&
+                            if (invalidSPDXLicenses.indexOf(license) >= 0) {
+                                licenseMatch = true;
+                            } else if (
+                                spdxCorrect(license) &&
                 spdxSatisfies(spdxCorrect(license), spdxExcluder)
-              ) {
-                licenseMatch = true;
-              }
-            }
-          });
-          if (!licenseMatch) {
-            filtered[item] = sorted[item];
-          }
+                            ) {
+                                licenseMatch = true;
+                            }
+                        }
+                    });
+                    if (!licenseMatch) {
+                        filtered[item] = sorted[item];
+                    }
+                }
+            });
+        } else {
+            filtered = sorted;
         }
-      });
-    } else {
-      filtered = sorted;
-    }
 
-    var restricted = filtered;
+        var restricted = filtered;
 
-    // package whitelist
-    if (options.packages) {
-      var packages = options.packages.split(";");
-      restricted = {};
-      Object.keys(filtered).map(function (key) {
-        if (packages.includes(key)) {
-          restricted[key] = filtered[key];
+        // package whitelist
+        if (options.packages) {
+            var packages = options.packages.split(";");
+            restricted = {};
+            Object.keys(filtered).map(function(key) {
+                if (packages.includes(key)) {
+                    restricted[key] = filtered[key];
+                }
+            });
         }
-      });
-    }
 
-    // package blacklist
-    if (options.excludePackages) {
-      var excludedPackages = options.excludePackages.split(";");
-      restricted = {};
-      Object.keys(filtered).map(function (key) {
-        if (!excludedPackages.includes(key)) {
-          restricted[key] = filtered[key];
+        // package blacklist
+        if (options.excludePackages) {
+            var excludedPackages = options.excludePackages.split(";");
+            restricted = {};
+            Object.keys(filtered).map(function(key) {
+                if (!excludedPackages.includes(key)) {
+                    restricted[key] = filtered[key];
+                }
+            });
         }
-      });
-    }
 
-    if (options.excludePrivatePackages) {
-      Object.keys(filtered).forEach(function (key) {
-        /*istanbul ignore next - I don't have access to private packages to test */
-        if (restricted[key] && restricted[key].private) {
-          delete restricted[key];
+        if (options.excludePrivatePackages) {
+            Object.keys(filtered).forEach(function(key) {
+                /*istanbul ignore next - I don't have access to private packages to test */
+                if (restricted[key] && restricted[key].private) {
+                    delete restricted[key];
+                }
+            });
         }
-      });
-    }
 
-    Object.keys(restricted).forEach(function (item) {
-      if (toCheckforFailOn.length > 0) {
-        if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
-          console.error(
-            'Found license defined by the --failOn flag: "' +
+        Object.keys(restricted).forEach(function(item) {
+            if (toCheckforFailOn.length > 0) {
+                if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
+                    console.error(
+                        'Found license defined by the --failOn flag: "' +
               restricted[item].licenses +
               '". Exiting.'
-          );
-          process.exit(1);
-        }
-        if (options.failOnRegEx) {
-          toCheckforFailOn.map((lic) => {
-            if (lic.match(restricted[item].licenses)) {
-              console.error(
-                'Found license defined by the --failOnRegEx flag: "' +
-                  restricted[item].licenses +
-                  '". Exiting.'
-              );
-              process.exit(1);
+                    );
+                    process.exit(1);
+                }
             }
-          });
-        }
-      }
-      if (toCheckforOnlyAllow.length > 0) {
-        var good = false;
-        toCheckforOnlyAllow.forEach(function (k) {
-          if (restricted[item].licenses.indexOf(k) === -1 && !good) {
-            good = false;
-          } else {
-            good = true;
-          }
-        });
-        if (!good) {
-          console.error(
-            'Package "' +
+            if (toCheckforFailOnRegEx.length > 0) {
+                toCheckforFailOnRegEx.map((lic) => {
+                    if (lic.match(restricted[item].licenses)) {
+                        console.error(
+                            'Found license defined by the --failOnRegEx flag: "' +
+                restricted[item].licenses +
+                '". Exiting.'
+                        );
+                        process.exit(1);
+                    }
+                });
+            }
+            if (toCheckforOnlyAllow.length > 0) {
+                var good = false;
+                toCheckforOnlyAllow.forEach(function(k) {
+                    if (restricted[item].licenses.indexOf(k) === -1 && !good) {
+                        good = false;
+                    } else {
+                        good = true;
+                    }
+                });
+                if (!good) {
+                    console.error(
+                        'Package "' +
               item +
               '" is licensed under "' +
               restricted[item].licenses +
               '" which is not permitted by the --onlyAllow flag. Exiting.'
-          );
-          process.exit(1);
+                    );
+                    process.exit(1);
+                }
+            }
+        });
+
+        /*istanbul ignore next*/
+        if (err) {
+            debugError(err);
+            inputError = err;
         }
-      }
+
+        //Return the callback and variables nicely
+        callback(inputError, restricted);
     });
-
-    /*istanbul ignore next*/
-    if (err) {
-      debugError(err);
-      inputError = err;
-    }
-
-    //Return the callback and variables nicely
-    callback(inputError, restricted);
-  });
 };
 
-exports.print = function (sorted) {
-  console.log(exports.asTree(sorted));
+exports.print = function(sorted) {
+    console.log(exports.asTree(sorted));
 };
 
-exports.asTree = function (sorted) {
-  return treeify.asTree(sorted, true);
+exports.asTree = function(sorted) {
+    return treeify.asTree(sorted, true);
 };
 
-exports.asSummary = function (sorted) {
-  var licenseCountObj = {};
-  var licenceCountArray = [];
-  var sortedLicenseCountObj = {};
+exports.asSummary = function(sorted) {
+    var licenseCountObj = {};
+    var licenceCountArray = [];
+    var sortedLicenseCountObj = {};
 
-  Object.keys(sorted).forEach(function (key) {
+    Object.keys(sorted).forEach(function(key) {
     /*istanbul ignore else*/
-    if (sorted[key].licenses) {
-      licenseCountObj[sorted[key].licenses] =
+        if (sorted[key].licenses) {
+            licenseCountObj[sorted[key].licenses] =
         licenseCountObj[sorted[key].licenses] || 0;
-      licenseCountObj[sorted[key].licenses]++;
-    }
-  });
-
-  Object.keys(licenseCountObj).forEach(function (license) {
-    licenceCountArray.push({
-      license: license,
-      count: licenseCountObj[license],
+            licenseCountObj[sorted[key].licenses]++;
+        }
     });
-  });
 
-  /*istanbul ignore next*/
-  licenceCountArray.sort(function (a, b) {
-    return b["count"] - a["count"];
-  });
+    Object.keys(licenseCountObj).forEach(function(license) {
+        licenceCountArray.push({
+            license: license,
+            count: licenseCountObj[license],
+        });
+    });
 
-  licenceCountArray.forEach(function (licenseObj) {
-    sortedLicenseCountObj[licenseObj.license] = licenseObj.count;
-  });
+    /*istanbul ignore next*/
+    licenceCountArray.sort(function(a, b) {
+        return b["count"] - a["count"];
+    });
 
-  return treeify.asTree(sortedLicenseCountObj, true);
+    licenceCountArray.forEach(function(licenseObj) {
+        sortedLicenseCountObj[licenseObj.license] = licenseObj.count;
+    });
+
+    return treeify.asTree(sortedLicenseCountObj, true);
 };
 
-exports.asCSV = function (sorted, customFormat, csvComponentPrefix) {
-  var text = [],
-    textArr = [],
-    lineArr = [];
-  var prefixName = '"component"';
-  var prefix = csvComponentPrefix;
+exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
+    var text = [],
+        textArr = [],
+        lineArr = [];
+    var prefixName = '"component"';
+    var prefix = csvComponentPrefix;
 
-  if (customFormat && Object.keys(customFormat).length > 0) {
-    textArr = [];
-    if (csvComponentPrefix) {
-      textArr.push(prefixName);
-    }
-    textArr.push('"module name"');
-    Object.keys(customFormat).forEach(function forEachCallback(item) {
-      textArr.push('"' + item + '"');
-    });
-    text.push(textArr.join(","));
-  } else {
-    textArr = [];
-    /*istanbul ignore next*/
-    if (csvComponentPrefix) {
-      textArr.push(prefixName);
-    }
-    ['"module name"', '"license"', '"repository"'].forEach(function (item) {
-      textArr.push(item);
-    });
-    text.push(textArr.join(","));
-  }
-
-  Object.keys(sorted).forEach(function (key) {
-    var module = sorted[key],
-      line = "";
-    lineArr = [];
-
-    //Grab the custom keys from the custom format
     if (customFormat && Object.keys(customFormat).length > 0) {
-      if (csvComponentPrefix) {
-        lineArr.push('"' + prefix + '"');
-      }
-      lineArr.push('"' + key + '"');
-      Object.keys(customFormat).forEach(function forEachCallback(item) {
-        lineArr.push('"' + module[item] + '"');
-      });
-      line = lineArr.join(",");
+        textArr = [];
+        if (csvComponentPrefix) {
+            textArr.push(prefixName);
+        }
+        textArr.push('"module name"');
+        Object.keys(customFormat).forEach(function forEachCallback(item) {
+            textArr.push('"' + item + '"');
+        });
+        text.push(textArr.join(","));
     } else {
-      /*istanbul ignore next*/
-      if (csvComponentPrefix) {
-        lineArr.push('"' + prefix + '"');
-      }
-      lineArr.push([
-        '"' + key + '"',
-        '"' + (module.licenses || "") + '"',
-        '"' + (module.repository || "") + '"',
-      ]);
-      line = lineArr.join(",");
+        textArr = [];
+        /*istanbul ignore next*/
+        if (csvComponentPrefix) {
+            textArr.push(prefixName);
+        }
+        ['"module name"', '"license"', '"repository"'].forEach(function(item) {
+            textArr.push(item);
+        });
+        text.push(textArr.join(","));
     }
-    text.push(line);
-  });
 
-  return text.join("\n");
+    Object.keys(sorted).forEach(function(key) {
+        var module = sorted[key],
+            line = "";
+        lineArr = [];
+
+        //Grab the custom keys from the custom format
+        if (customFormat && Object.keys(customFormat).length > 0) {
+            if (csvComponentPrefix) {
+                lineArr.push('"' + prefix + '"');
+            }
+            lineArr.push('"' + key + '"');
+            Object.keys(customFormat).forEach(function forEachCallback(item) {
+                lineArr.push('"' + module[item] + '"');
+            });
+            line = lineArr.join(",");
+        } else {
+            /*istanbul ignore next*/
+            if (csvComponentPrefix) {
+                lineArr.push('"' + prefix + '"');
+            }
+            lineArr.push([
+                '"' + key + '"',
+                '"' + (module.licenses || "") + '"',
+                '"' + (module.repository || "") + '"',
+            ]);
+            line = lineArr.join(",");
+        }
+        text.push(line);
+    });
+
+    return text.join("\n");
 };
 
 /**
@@ -667,68 +681,68 @@ exports.asCSV = function (sorted, customFormat, csvComponentPrefix) {
  * @param  {JSON} customFormat The custom format with information about the needed keys.
  * @return {String}            The returning plain text.
  */
-exports.asMarkDown = function (sorted, customFormat) {
-  var text = [];
-  if (customFormat && Object.keys(customFormat).length > 0) {
-    Object.keys(sorted).forEach(function sortedCallback(sortedItem) {
-      text.push(
-        " - **[" + sortedItem + "](" + sorted[sortedItem].repository + ")**"
-      );
-      Object.keys(customFormat).forEach(function customCallback(customItem) {
-        text.push(
-          "    - " + customItem + ": " + sorted[sortedItem][customItem]
-        );
-      });
-    });
-    text = text.join("\n");
-  } else {
-    Object.keys(sorted).forEach(function (key) {
-      var module = sorted[key];
-      text.push(
-        "[" + key + "](" + module.repository + ") - " + module.licenses
-      );
-    });
-    text = text.join("\n");
-  }
-
-  return text;
-};
-
-exports.parseJson = function (jsonPath) {
-  if (typeof jsonPath !== "string") {
-    return new Error("did not specify a path");
-  }
-
-  var jsonFileContents = "",
-    result = {};
-
-  try {
-    jsonFileContents = fs.readFileSync(jsonPath, { encoding: "utf8" });
-    result = JSON.parse(jsonFileContents);
-  } catch (err) {
-    result = err;
-  }
-  return result;
-};
-
-exports.asFiles = function (json, outDir) {
-  mkdirp.sync(outDir);
-  Object.keys(json).forEach(function (moduleName) {
-    var licenseFile = json[moduleName].licenseFile,
-      fileContents,
-      outFileName,
-      outPath,
-      baseDir;
-
-    if (licenseFile && fs.existsSync(licenseFile)) {
-      fileContents = fs.readFileSync(licenseFile);
-      outFileName = moduleName + "-LICENSE.txt";
-      outPath = path.join(outDir, outFileName);
-      baseDir = path.dirname(outPath);
-      mkdirp.sync(baseDir);
-      fs.writeFileSync(outPath, fileContents, "utf8");
+exports.asMarkDown = function(sorted, customFormat) {
+    var text = [];
+    if (customFormat && Object.keys(customFormat).length > 0) {
+        Object.keys(sorted).forEach(function sortedCallback(sortedItem) {
+            text.push(
+                " - **[" + sortedItem + "](" + sorted[sortedItem].repository + ")**"
+            );
+            Object.keys(customFormat).forEach(function customCallback(customItem) {
+                text.push(
+                    "    - " + customItem + ": " + sorted[sortedItem][customItem]
+                );
+            });
+        });
+        text = text.join("\n");
     } else {
-      console.warn("no license file found for: " + moduleName);
+        Object.keys(sorted).forEach(function(key) {
+            var module = sorted[key];
+            text.push(
+                "[" + key + "](" + module.repository + ") - " + module.licenses
+            );
+        });
+        text = text.join("\n");
     }
-  });
+
+    return text;
+};
+
+exports.parseJson = function(jsonPath) {
+    if (typeof jsonPath !== "string") {
+        return new Error("did not specify a path");
+    }
+
+    var jsonFileContents = "",
+        result = {};
+
+    try {
+        jsonFileContents = fs.readFileSync(jsonPath, { encoding: "utf8" });
+        result = JSON.parse(jsonFileContents);
+    } catch (err) {
+        result = err;
+    }
+    return result;
+};
+
+exports.asFiles = function(json, outDir) {
+    mkdirp.sync(outDir);
+    Object.keys(json).forEach(function(moduleName) {
+        var licenseFile = json[moduleName].licenseFile,
+            fileContents,
+            outFileName,
+            outPath,
+            baseDir;
+
+        if (licenseFile && fs.existsSync(licenseFile)) {
+            fileContents = fs.readFileSync(licenseFile);
+            outFileName = moduleName + "-LICENSE.txt";
+            outPath = path.join(outDir, outFileName);
+            baseDir = path.dirname(outPath);
+            mkdirp.sync(baseDir);
+            fs.writeFileSync(outPath, fileContents, "utf8");
+        } else {
+            console.warn("no license file found for: " + moduleName);
+        }
+    });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,624 +4,731 @@ Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
 
-var UNKNOWN = 'UNKNOWN';
-var UNLICENSED = 'UNLICENSED';
-var fs = require('fs');
-var path = require('path');
-var read = require('read-installed');
-var chalk = require('chalk');
-var treeify = require('treeify');
-var license = require('./license');
-var licenseFiles = require('./license-files');
-var debug = require('debug');
-var mkdirp = require('mkdirp');
-var spdxSatisfies = require('spdx-satisfies');
-var spdxCorrect =require('spdx-correct');
+var UNKNOWN = "UNKNOWN";
+var UNLICENSED = "UNLICENSED";
+var fs = require("fs");
+var path = require("path");
+var read = require("read-installed");
+var chalk = require("chalk");
+var treeify = require("treeify");
+var license = require("./license");
+var licenseFiles = require("./license-files");
+var debug = require("debug");
+var mkdirp = require("mkdirp");
+var spdxSatisfies = require("spdx-satisfies");
+var spdxCorrect = require("spdx-correct");
 
 // Set up debug logging
 // https://www.npmjs.com/package/debug#stderr-vs-stdout
-var debugError = debug('license-checker:error');
-var debugLog = debug('license-checker:log');
+var debugError = debug("license-checker:error");
+var debugLog = debug("license-checker:log");
 debugLog.log = console.log.bind(console);
 
-var flatten = function(options) {
-    var moduleInfo = { licenses: UNKNOWN },
-        json = options.deps,
-        data = options.data,
-        key = json.name + '@' + json.version,
-        colorize = options.color,
-        unknown = options.unknown,
-        readmeFile,
-        licenseData, dirFiles, files = [], noticeFiles = [], licenseFile;
+var flatten = function (options) {
+  var moduleInfo = { licenses: UNKNOWN },
+    json = options.deps,
+    data = options.data,
+    key = json.name + "@" + json.version,
+    colorize = options.color,
+    unknown = options.unknown,
+    readmeFile,
+    licenseData,
+    dirFiles,
+    files = [],
+    noticeFiles = [],
+    licenseFile;
 
-    if (json.private) {
-        moduleInfo.private = true;
-    }
+  if (json.private) {
+    moduleInfo.private = true;
+  }
 
-    // If we have processed this key already, just return the data object.
-    // This was added so that we don't recurse forever if there was a circular
-    // dependency in the dependency tree.
-    /*istanbul ignore next*/
-    if (data[key]) {
-        return data;
-    }
-
-    if ((options.production && json.extraneous) || (options.development && !json.extraneous && !json.root)) {
-        return data;
-    }
-
-    data[key] = moduleInfo;
-
-    // Include property in output unless custom format has set property to false.
-    var include = function(property) {
-        return (options.customFormat === undefined || options.customFormat[property] !== false);
-    };
-
-    if (include("repository") && json.repository) {
-        /*istanbul ignore else*/
-        if (typeof json.repository === 'object' && typeof json.repository.url === 'string') {
-            moduleInfo.repository = json.repository.url.replace('git+ssh://git@', 'git://');
-            moduleInfo.repository = moduleInfo.repository.replace('git+https://github.com', 'https://github.com');
-            moduleInfo.repository = moduleInfo.repository.replace('git://github.com', 'https://github.com');
-            moduleInfo.repository = moduleInfo.repository.replace('git@github.com:', 'https://github.com/');
-            moduleInfo.repository = moduleInfo.repository.replace(/\.git$/, '');
-        }
-    }
-    if (include("url") && json.url) {
-        /*istanbul ignore next*/
-        if (typeof json.url === 'object') {
-            moduleInfo.url = json.url.web;
-        }
-    }
-    if (json.author && typeof json.author === 'object') {
-        /*istanbul ignore else - This should always be there*/
-        if (include("publisher") && json.author.name) {
-            moduleInfo.publisher = json.author.name;
-        }
-        if (include("email") && json.author.email) {
-            moduleInfo.email = json.author.email;
-        }
-        if (include("url") && json.author.url) {
-            moduleInfo.url = json.author.url;
-        }
-    }
-
-    /*istanbul ignore next*/
-    if (unknown) {
-        moduleInfo.dependencyPath = json.path;
-    }
-
-    /*istanbul ignore next*/
-    if (options.customFormat) {
-        Object.keys(options.customFormat).forEach(function forEachCallback(item) {
-            if (include(item) && json[item]) {
-                //For now, we only support strings, not JSON objects
-                if (typeof json[item] === 'string') {
-                    moduleInfo[item] = json[item];
-                }
-            } else if (include(item)) {
-                moduleInfo[item] = options.customFormat[item];
-            }
-        });
-    }
-
-    if (include("path") && json.path && typeof json.path === 'string') {
-        moduleInfo.path = json.path;
-    }
-
-    licenseData = json.license || json.licenses || undefined;
-
-    if (json.path && (!json.readme || json.readme.toLowerCase().indexOf('no readme data found') > -1)) {
-        readmeFile = path.join(json.path, 'README.md');
-        /*istanbul ignore if*/
-        if (fs.existsSync(readmeFile)) {
-            json.readme = fs.readFileSync(readmeFile, 'utf8').toString();
-        }
-    }
-
-    if (licenseData) {
-        /*istanbul ignore else*/
-        if (Array.isArray(licenseData) && licenseData.length > 0) {
-            moduleInfo.licenses = licenseData.map(function(license){
-                /*istanbul ignore else*/
-                if (typeof license === 'object') {
-                    /*istanbul ignore next*/
-                    return license.type || license.name;
-                } else if (typeof license === 'string') {
-                    return license;
-                }
-            });
-        } else if (typeof licenseData === 'object' && (licenseData.type || licenseData.name)) {
-            moduleInfo.licenses = license(licenseData.type || licenseData.name);
-        } else if (typeof licenseData === 'string') {
-            moduleInfo.licenses = license(licenseData);
-        }
-    } else if (license(json.readme)) {
-        moduleInfo.licenses = license(json.readme);
-    }
-
-    if (Array.isArray(moduleInfo.licenses)) {
-        /*istanbul ignore else*/
-        if (moduleInfo.licenses.length === 1) {
-            moduleInfo.licenses = moduleInfo.licenses[0];
-        }
-    }
-
-    /*istanbul ignore else*/
-    if (json.path && fs.existsSync(json.path)) {
-        dirFiles = fs.readdirSync(json.path);
-        files = licenseFiles(dirFiles);
-
-        noticeFiles = dirFiles.filter(function(filename) {
-            filename = filename.toUpperCase();
-            var name = path.basename(filename).replace(path.extname(filename), '');
-            return name === 'NOTICE';
-        });
-    }
-
-    files.forEach(function(filename, index) {
-        licenseFile = path.join(json.path, filename);
-        // Checking that the file is in fact a normal file and not a directory for example.
-        /*istanbul ignore else*/
-        if (fs.lstatSync(licenseFile).isFile()) {
-            var content;
-            if (!moduleInfo.licenses || moduleInfo.licenses.indexOf(UNKNOWN) > -1 || moduleInfo.licenses.indexOf('Custom:') === 0) {
-                //Only re-check the license if we didn't get it from elsewhere
-                content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
-                moduleInfo.licenses = license(content);
-            }
-
-            if (index === 0) {
-                // Treat the file with the highest precedence as licenseFile
-                /*istanbul ignore else*/
-                if (include("licenseFile")) {
-                    moduleInfo.licenseFile = options.basePath ? path.relative(options.basePath, licenseFile) : licenseFile;
-                }
-
-                if (include("licenseText") && options.customFormat) {
-                    if (!content) {
-                        content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
-                    }
-                    /*istanbul ignore else*/
-                    if (options._args && !options._args.csv) {
-                        moduleInfo.licenseText = content.trim();
-                    } else {
-                        moduleInfo.licenseText = content.replace(/"/g, '\'').replace(/\r?\n|\r/g, " ").trim();
-                    }
-                }
-
-                if(include('copyright') && options.customFormat) {
-                    if (!content) {
-                        content = fs.readFileSync(licenseFile, { encoding: 'utf8' });
-                    }
-
-                    var linesWithCopyright = content
-                        .replace(/\r\n/g, '\n')
-                        .split('\n\n')
-                        .filter(function selectCopyRightStatements(value) {
-                            return value.startsWith('opyright', 1) &&         // include copyright statements
-                                !value.startsWith('opyright notice', 1) &&    // exclude lines from from license text
-                                !value.startsWith('opyright and related rights', 1);
-                        })
-                        .filter(function removeDuplicates(value, index, list) {
-                            return index === 0 || value !== list[0];
-                        });
-
-                    if(linesWithCopyright.length > 0) {
-                        moduleInfo.copyright = linesWithCopyright[0]
-                            .replace(/\n/g, '. ')
-                            .trim();
-                    }
-                
-                    // Mark files with multiple copyright statements. This might be
-                    // an indicator to take a closer look at the LICENSE file.
-                    if(linesWithCopyright.length > 1) {
-                        moduleInfo.copyright += '*';
-                    }
-                }
-            }
-        }
-    });
-
-    noticeFiles.forEach(function(filename) {
-        var file = path.join(json.path, filename);
-        /*istanbul ignore else*/
-        if (fs.lstatSync(file).isFile()) {
-            moduleInfo.noticeFile = options.basePath ? path.relative(options.basePath, file) : file;
-        }
-    });
-
-    /*istanbul ignore else*/
-    if (json.dependencies) {
-        Object.keys(json.dependencies).forEach(function(name) {
-            var childDependency = json.dependencies[name],
-                dependencyId = childDependency.name + '@' + childDependency.version;
-            if (data[dependencyId]) { // already exists
-                return;
-            }
-            data = flatten({
-                deps: childDependency,
-                data: data,
-                color: colorize,
-                unknown: unknown,
-                customFormat: options.customFormat,
-                production: options.production,
-                development: options.development,
-                basePath: options.basePath,
-                _args: options._args
-            });
-        });
-    }
-    if (!json.name || !json.version) {
-        delete data[key];
-    }
+  // If we have processed this key already, just return the data object.
+  // This was added so that we don't recurse forever if there was a circular
+  // dependency in the dependency tree.
+  /*istanbul ignore next*/
+  if (data[key]) {
     return data;
+  }
+
+  if (
+    (options.production && json.extraneous) ||
+    (options.development && !json.extraneous && !json.root)
+  ) {
+    return data;
+  }
+
+  data[key] = moduleInfo;
+
+  // Include property in output unless custom format has set property to false.
+  var include = function (property) {
+    return (
+      options.customFormat === undefined ||
+      options.customFormat[property] !== false
+    );
+  };
+
+  if (include("repository") && json.repository) {
+    /*istanbul ignore else*/
+    if (
+      typeof json.repository === "object" &&
+      typeof json.repository.url === "string"
+    ) {
+      moduleInfo.repository = json.repository.url.replace(
+        "git+ssh://git@",
+        "git://"
+      );
+      moduleInfo.repository = moduleInfo.repository.replace(
+        "git+https://github.com",
+        "https://github.com"
+      );
+      moduleInfo.repository = moduleInfo.repository.replace(
+        "git://github.com",
+        "https://github.com"
+      );
+      moduleInfo.repository = moduleInfo.repository.replace(
+        "git@github.com:",
+        "https://github.com/"
+      );
+      moduleInfo.repository = moduleInfo.repository.replace(/\.git$/, "");
+    }
+  }
+  if (include("url") && json.url) {
+    /*istanbul ignore next*/
+    if (typeof json.url === "object") {
+      moduleInfo.url = json.url.web;
+    }
+  }
+  if (json.author && typeof json.author === "object") {
+    /*istanbul ignore else - This should always be there*/
+    if (include("publisher") && json.author.name) {
+      moduleInfo.publisher = json.author.name;
+    }
+    if (include("email") && json.author.email) {
+      moduleInfo.email = json.author.email;
+    }
+    if (include("url") && json.author.url) {
+      moduleInfo.url = json.author.url;
+    }
+  }
+
+  /*istanbul ignore next*/
+  if (unknown) {
+    moduleInfo.dependencyPath = json.path;
+  }
+
+  /*istanbul ignore next*/
+  if (options.customFormat) {
+    Object.keys(options.customFormat).forEach(function forEachCallback(item) {
+      if (include(item) && json[item]) {
+        //For now, we only support strings, not JSON objects
+        if (typeof json[item] === "string") {
+          moduleInfo[item] = json[item];
+        }
+      } else if (include(item)) {
+        moduleInfo[item] = options.customFormat[item];
+      }
+    });
+  }
+
+  if (include("path") && json.path && typeof json.path === "string") {
+    moduleInfo.path = json.path;
+  }
+
+  licenseData = json.license || json.licenses || undefined;
+
+  if (
+    json.path &&
+    (!json.readme ||
+      json.readme.toLowerCase().indexOf("no readme data found") > -1)
+  ) {
+    readmeFile = path.join(json.path, "README.md");
+    /*istanbul ignore if*/
+    if (fs.existsSync(readmeFile)) {
+      json.readme = fs.readFileSync(readmeFile, "utf8").toString();
+    }
+  }
+
+  if (licenseData) {
+    /*istanbul ignore else*/
+    if (Array.isArray(licenseData) && licenseData.length > 0) {
+      moduleInfo.licenses = licenseData.map(function (license) {
+        /*istanbul ignore else*/
+        if (typeof license === "object") {
+          /*istanbul ignore next*/
+          return license.type || license.name;
+        } else if (typeof license === "string") {
+          return license;
+        }
+      });
+    } else if (
+      typeof licenseData === "object" &&
+      (licenseData.type || licenseData.name)
+    ) {
+      moduleInfo.licenses = license(licenseData.type || licenseData.name);
+    } else if (typeof licenseData === "string") {
+      moduleInfo.licenses = license(licenseData);
+    }
+  } else if (license(json.readme)) {
+    moduleInfo.licenses = license(json.readme);
+  }
+
+  if (Array.isArray(moduleInfo.licenses)) {
+    /*istanbul ignore else*/
+    if (moduleInfo.licenses.length === 1) {
+      moduleInfo.licenses = moduleInfo.licenses[0];
+    }
+  }
+
+  /*istanbul ignore else*/
+  if (json.path && fs.existsSync(json.path)) {
+    dirFiles = fs.readdirSync(json.path);
+    files = licenseFiles(dirFiles);
+
+    noticeFiles = dirFiles.filter(function (filename) {
+      filename = filename.toUpperCase();
+      var name = path.basename(filename).replace(path.extname(filename), "");
+      return name === "NOTICE";
+    });
+  }
+
+  files.forEach(function (filename, index) {
+    licenseFile = path.join(json.path, filename);
+    // Checking that the file is in fact a normal file and not a directory for example.
+    /*istanbul ignore else*/
+    if (fs.lstatSync(licenseFile).isFile()) {
+      var content;
+      if (
+        !moduleInfo.licenses ||
+        moduleInfo.licenses.indexOf(UNKNOWN) > -1 ||
+        moduleInfo.licenses.indexOf("Custom:") === 0
+      ) {
+        //Only re-check the license if we didn't get it from elsewhere
+        content = fs.readFileSync(licenseFile, { encoding: "utf8" });
+        moduleInfo.licenses = license(content);
+      }
+
+      if (index === 0) {
+        // Treat the file with the highest precedence as licenseFile
+        /*istanbul ignore else*/
+        if (include("licenseFile")) {
+          moduleInfo.licenseFile = options.basePath
+            ? path.relative(options.basePath, licenseFile)
+            : licenseFile;
+        }
+
+        if (include("licenseText") && options.customFormat) {
+          if (!content) {
+            content = fs.readFileSync(licenseFile, { encoding: "utf8" });
+          }
+          /*istanbul ignore else*/
+          if (options._args && !options._args.csv) {
+            moduleInfo.licenseText = content.trim();
+          } else {
+            moduleInfo.licenseText = content
+              .replace(/"/g, "'")
+              .replace(/\r?\n|\r/g, " ")
+              .trim();
+          }
+        }
+
+        if (include("copyright") && options.customFormat) {
+          if (!content) {
+            content = fs.readFileSync(licenseFile, { encoding: "utf8" });
+          }
+
+          var linesWithCopyright = content
+            .replace(/\r\n/g, "\n")
+            .split("\n\n")
+            .filter(function selectCopyRightStatements(value) {
+              return (
+                value.startsWith("opyright", 1) && // include copyright statements
+                !value.startsWith("opyright notice", 1) && // exclude lines from from license text
+                !value.startsWith("opyright and related rights", 1)
+              );
+            })
+            .filter(function removeDuplicates(value, index, list) {
+              return index === 0 || value !== list[0];
+            });
+
+          if (linesWithCopyright.length > 0) {
+            moduleInfo.copyright = linesWithCopyright[0]
+              .replace(/\n/g, ". ")
+              .trim();
+          }
+
+          // Mark files with multiple copyright statements. This might be
+          // an indicator to take a closer look at the LICENSE file.
+          if (linesWithCopyright.length > 1) {
+            moduleInfo.copyright += "*";
+          }
+        }
+      }
+    }
+  });
+
+  noticeFiles.forEach(function (filename) {
+    var file = path.join(json.path, filename);
+    /*istanbul ignore else*/
+    if (fs.lstatSync(file).isFile()) {
+      moduleInfo.noticeFile = options.basePath
+        ? path.relative(options.basePath, file)
+        : file;
+    }
+  });
+
+  /*istanbul ignore else*/
+  if (json.dependencies) {
+    Object.keys(json.dependencies).forEach(function (name) {
+      var childDependency = json.dependencies[name],
+        dependencyId = childDependency.name + "@" + childDependency.version;
+      if (data[dependencyId]) {
+        // already exists
+        return;
+      }
+      data = flatten({
+        deps: childDependency,
+        data: data,
+        color: colorize,
+        unknown: unknown,
+        customFormat: options.customFormat,
+        production: options.production,
+        development: options.development,
+        basePath: options.basePath,
+        _args: options._args,
+      });
+    });
+  }
+  if (!json.name || !json.version) {
+    delete data[key];
+  }
+  return data;
 };
 
-exports.init = function(options, callback) {
-    debugLog('scanning %s', options.start);
+exports.init = function (options, callback) {
+  debugLog("scanning %s", options.start);
 
-    if (options.customPath) {
-        options.customFormat = this.parseJson(options.customPath);
-    }
-    var opts = {
-        dev: true,
-        log: debugLog,
-        depth: options.direct
+  if (options.customPath) {
+    options.customFormat = this.parseJson(options.customPath);
+  }
+  var opts = {
+    dev: true,
+    log: debugLog,
+    depth: options.direct,
+  };
+
+  if (options.production || options.development) {
+    opts.dev = false;
+  }
+
+  var toCheckforFailOn = [];
+  var toCheckforOnlyAllow = [];
+  var checker, pusher;
+  if (options.onlyAllow) {
+    checker = options.onlyAllow;
+    pusher = toCheckforOnlyAllow;
+  }
+  if (options.failOn || options.failOnRegEx) {
+    checker = options.failOn || options.failOnRegEx;
+    pusher = toCheckforFailOn;
+  }
+  if (checker && pusher) {
+    checker.split(";").forEach(function (license) {
+      var trimmed = license.trim();
+      /*istanbul ignore else*/
+      if (trimmed.length > 0) {
+        pusher.push(trimmed);
+      }
+    });
+  }
+
+  read(options.start, opts, function (err, json) {
+    var data = flatten({
+        deps: json,
+        data: {},
+        color: options.color,
+        unknown: options.unknown,
+        customFormat: options.customFormat,
+        production: options.production,
+        development: options.development,
+        basePath: options.relativeLicensePath ? json.path : null,
+        _args: options,
+      }),
+      colorize = options.color,
+      sorted = {},
+      filtered = {},
+      exclude =
+        options.exclude &&
+        options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function (license) {
+          return license.replace(/\\,/g, ",").replace(/^\s+|\s+$/g, "");
+        }),
+      inputError = null;
+
+    var colorizeString = function (string) {
+      /*istanbul ignore next*/
+      return colorize ? chalk.bold.red(string) : string;
     };
 
-    if (options.production || options.development) {
-        opts.dev = false;
-    }
-
-    var toCheckforFailOn = [];
-    var toCheckforOnlyAllow = [];
-    var checker, pusher;
-    if (options.onlyAllow) {
-        checker = options.onlyAllow;
-        pusher = toCheckforOnlyAllow;
-    }
-    if (options.failOn) {
-        checker = options.failOn;
-        pusher = toCheckforFailOn;
-    }
-    if (checker && pusher) {
-        checker.split(';').forEach(function(license) {
-            var trimmed = license.trim();
-            /*istanbul ignore else*/
-            if (trimmed.length > 0) {
-                pusher.push(trimmed);
-            }
-        });
-    }
-
-    read(options.start, opts, function(err, json) {
-        var data = flatten({
-                deps: json,
-                data: {},
-                color: options.color,
-                unknown: options.unknown,
-                customFormat: options.customFormat,
-                production: options.production,
-                development: options.development,
-                basePath: options.relativeLicensePath ? json.path : null,
-                _args: options
-            }),
-            colorize = options.color,
-            sorted = {},
-            filtered = {},
-            exclude = options.exclude && options.exclude.match(/([^\\\][^,]|\\,)+/g).map(function(license) {
-                return license.replace(/\\,/g, ',').replace(/^\s+|\s+$/g, '');
-            }),
-            inputError = null;
-
-        var colorizeString = function(string) {
-            /*istanbul ignore next*/
-            return colorize ? chalk.bold.red(string) : string;
-        };
-
-        Object.keys(data).sort().forEach(function(item) {
-            if (data[item].private) {
-                data[item].licenses = colorizeString(UNLICENSED);
-            }
-            /*istanbul ignore next*/
-            if (!data[item].licenses) {
-                data[item].licenses = colorizeString(UNKNOWN);
-            }
-            if (options.unknown) {
-                /*istanbul ignore else*/
-                if (data[item].licenses && data[item].licenses !== UNKNOWN) {
-                    if (data[item].licenses.indexOf('*') > -1) {
-                        /*istanbul ignore if*/
-                        data[item].licenses = colorizeString(UNKNOWN);
-                    }
-                }
-            }
-            /*istanbul ignore else*/
-            if (data[item]) {
-                if (options.onlyunknown) {
-                    if (data[item].licenses.indexOf('*') > -1 ||
-                        data[item].licenses.indexOf(UNKNOWN) > -1) {
-                        sorted[item] = data[item];
-                    }
-                } else {
-                    sorted[item] = data[item];
-                }
-            }
-        });
-
-        if (!Object.keys(sorted).length) {
-            err = new Error('No packages found in this path..');
+    Object.keys(data)
+      .sort()
+      .forEach(function (item) {
+        if (data[item].private) {
+          data[item].licenses = colorizeString(UNLICENSED);
         }
-
-        if (exclude) {
-            var transformBSD = function(spdx) {
-                return spdx === 'BSD' ? '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)' : spdx;
-            };
-            var invert = function(fn) { return function(spdx) { return !fn(spdx);};};
-            var spdxIsValid = function(spdx) { return spdxCorrect(spdx) === spdx; };
-
-            var validSPDXLicenses = exclude.map(transformBSD).filter(spdxIsValid);
-            var invalidSPDXLicenses = exclude.map(transformBSD).filter(invert(spdxIsValid));
-            var spdxExcluder = '( ' + validSPDXLicenses.join(' OR ') + ' )';
-
-            Object.keys(sorted).forEach(function(item) {
-                var licenses = sorted[item].licenses;
-                /*istanbul ignore if - just for protection*/
-                if(!licenses) {
-                    filtered[item] = sorted[item];
-                } else {
-                    licenses = [].concat(licenses);
-                    var licenseMatch = false;
-                    licenses.forEach(function(license) {
-                        /*istanbul ignore if - just for protection*/
-                        if (license.indexOf(UNKNOWN) >= 0) { // necessary due to colorization
-                            filtered[item] = sorted[item];
-                        } else {
-                            if(license.indexOf('*') >= 0) {
-                                license = license.substring(0, license.length - 1);
-                            }
-                            if(license === 'BSD') {
-                                license = '(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)';
-                            }
-
-                            if (invalidSPDXLicenses.indexOf(license) >= 0) {
-                                licenseMatch = true;
-                            } else if (spdxCorrect(license) && spdxSatisfies(spdxCorrect(license), spdxExcluder)) {
-                                licenseMatch = true;
-                            }
-                        }
-                    });
-                    if(!licenseMatch) {
-                        filtered[item] = sorted[item];
-                    }
-                }
-            });
-        } else {
-            filtered = sorted;
-        }
-
-        var restricted = filtered;
-
-        // package whitelist
-        if (options.packages) {
-            var packages = options.packages.split(';');
-            restricted = {};
-            Object.keys(filtered).map(function(key) {
-                if (packages.includes(key)) {
-                    restricted[key] = filtered[key];
-                }
-            });
-        }
-
-        // package blacklist
-        if (options.excludePackages) {
-            var excludedPackages = options.excludePackages.split(';');
-            restricted = {};
-            Object.keys(filtered).map(function(key) {
-                if (!excludedPackages.includes(key)) {
-                    restricted[key] = filtered[key];
-                }
-            });
-        }
-
-        if (options.excludePrivatePackages) {
-            Object.keys(filtered).forEach(function(key) {
-                /*istanbul ignore next - I don't have access to private packages to test */
-                if (restricted[key] && restricted[key].private) {
-                    delete restricted[key];
-                }
-            });
-        }
-
-        Object.keys(restricted).forEach(function(item) {
-            if (toCheckforFailOn.length > 0) {
-                if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
-                    console.error('Found license defined by the --failOn flag: "' + restricted[item].licenses + '". Exiting.');
-                    process.exit(1);
-                }
-            }
-            if (toCheckforOnlyAllow.length > 0) {
-                var good = false;
-                toCheckforOnlyAllow.forEach(function(k) {
-                    if (restricted[item].licenses.indexOf(k) === -1 && !good) {
-                        good = false;
-                    } else {
-                        good = true;
-                    }
-                });
-                if (!good) {
-                    console.error('Package "' + item + '" is licensed under "' + restricted[item].licenses + '" which is not permitted by the --onlyAllow flag. Exiting.');
-                    process.exit(1);
-                }
-            }
-        });
-
         /*istanbul ignore next*/
-        if (err) {
-            debugError(err);
-            inputError = err;
+        if (!data[item].licenses) {
+          data[item].licenses = colorizeString(UNKNOWN);
         }
-
-        //Return the callback and variables nicely
-        callback(inputError, restricted);
-    });
-};
-
-exports.print = function(sorted) {
-    console.log(exports.asTree(sorted));
-};
-
-exports.asTree = function(sorted) {
-    return treeify.asTree(sorted, true);
-};
-
-exports.asSummary = function(sorted) {
-    var licenseCountObj = {};
-    var licenceCountArray = [];
-    var sortedLicenseCountObj = {};
-
-    Object.keys(sorted).forEach(function(key) {
+        if (options.unknown) {
+          /*istanbul ignore else*/
+          if (data[item].licenses && data[item].licenses !== UNKNOWN) {
+            if (data[item].licenses.indexOf("*") > -1) {
+              /*istanbul ignore if*/
+              data[item].licenses = colorizeString(UNKNOWN);
+            }
+          }
+        }
         /*istanbul ignore else*/
-        if (sorted[key].licenses) {
-            licenseCountObj[sorted[key].licenses] = licenseCountObj[sorted[key].licenses] || 0;
-            licenseCountObj[sorted[key].licenses]++;
+        if (data[item]) {
+          if (options.onlyunknown) {
+            if (
+              data[item].licenses.indexOf("*") > -1 ||
+              data[item].licenses.indexOf(UNKNOWN) > -1
+            ) {
+              sorted[item] = data[item];
+            }
+          } else {
+            sorted[item] = data[item];
+          }
         }
-    });
+      });
 
-    Object.keys(licenseCountObj).forEach(function(license) {
-        licenceCountArray.push({ license: license, count: licenseCountObj[license] });
+    if (!Object.keys(sorted).length) {
+      err = new Error("No packages found in this path..");
+    }
+
+    if (exclude) {
+      var transformBSD = function (spdx) {
+        return spdx === "BSD"
+          ? "(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)"
+          : spdx;
+      };
+      var invert = function (fn) {
+        return function (spdx) {
+          return !fn(spdx);
+        };
+      };
+      var spdxIsValid = function (spdx) {
+        return spdxCorrect(spdx) === spdx;
+      };
+
+      var validSPDXLicenses = exclude.map(transformBSD).filter(spdxIsValid);
+      var invalidSPDXLicenses = exclude
+        .map(transformBSD)
+        .filter(invert(spdxIsValid));
+      var spdxExcluder = "( " + validSPDXLicenses.join(" OR ") + " )";
+
+      Object.keys(sorted).forEach(function (item) {
+        var licenses = sorted[item].licenses;
+        /*istanbul ignore if - just for protection*/
+        if (!licenses) {
+          filtered[item] = sorted[item];
+        } else {
+          licenses = [].concat(licenses);
+          var licenseMatch = false;
+          licenses.forEach(function (license) {
+            /*istanbul ignore if - just for protection*/
+            if (license.indexOf(UNKNOWN) >= 0) {
+              // necessary due to colorization
+              filtered[item] = sorted[item];
+            } else {
+              if (license.indexOf("*") >= 0) {
+                license = license.substring(0, license.length - 1);
+              }
+              if (license === "BSD") {
+                license =
+                  "(0BSD OR BSD-2-Clause OR BSD-3-Clause OR BSD-4-Clause)";
+              }
+
+              if (invalidSPDXLicenses.indexOf(license) >= 0) {
+                licenseMatch = true;
+              } else if (
+                spdxCorrect(license) &&
+                spdxSatisfies(spdxCorrect(license), spdxExcluder)
+              ) {
+                licenseMatch = true;
+              }
+            }
+          });
+          if (!licenseMatch) {
+            filtered[item] = sorted[item];
+          }
+        }
+      });
+    } else {
+      filtered = sorted;
+    }
+
+    var restricted = filtered;
+
+    // package whitelist
+    if (options.packages) {
+      var packages = options.packages.split(";");
+      restricted = {};
+      Object.keys(filtered).map(function (key) {
+        if (packages.includes(key)) {
+          restricted[key] = filtered[key];
+        }
+      });
+    }
+
+    // package blacklist
+    if (options.excludePackages) {
+      var excludedPackages = options.excludePackages.split(";");
+      restricted = {};
+      Object.keys(filtered).map(function (key) {
+        if (!excludedPackages.includes(key)) {
+          restricted[key] = filtered[key];
+        }
+      });
+    }
+
+    if (options.excludePrivatePackages) {
+      Object.keys(filtered).forEach(function (key) {
+        /*istanbul ignore next - I don't have access to private packages to test */
+        if (restricted[key] && restricted[key].private) {
+          delete restricted[key];
+        }
+      });
+    }
+
+    Object.keys(restricted).forEach(function (item) {
+      if (toCheckforFailOn.length > 0) {
+        if (toCheckforFailOn.indexOf(restricted[item].licenses) > -1) {
+          console.error(
+            'Found license defined by the --failOn flag: "' +
+              restricted[item].licenses +
+              '". Exiting.'
+          );
+          process.exit(1);
+        }
+        if (options.failOnRegEx) {
+          toCheckforFailOn.map((lic) => {
+            if (lic.match(restricted[item].licenses)) {
+              console.error(
+                'Found license defined by the --failOnRegEx flag: "' +
+                  restricted[item].licenses +
+                  '". Exiting.'
+              );
+              process.exit(1);
+            }
+          });
+        }
+      }
+      if (toCheckforOnlyAllow.length > 0) {
+        var good = false;
+        toCheckforOnlyAllow.forEach(function (k) {
+          if (restricted[item].licenses.indexOf(k) === -1 && !good) {
+            good = false;
+          } else {
+            good = true;
+          }
+        });
+        if (!good) {
+          console.error(
+            'Package "' +
+              item +
+              '" is licensed under "' +
+              restricted[item].licenses +
+              '" which is not permitted by the --onlyAllow flag. Exiting.'
+          );
+          process.exit(1);
+        }
+      }
     });
 
     /*istanbul ignore next*/
-    licenceCountArray.sort(function(a, b) {
-        return b['count'] - a['count'];
-    });
-
-    licenceCountArray.forEach(function(licenseObj) {
-        sortedLicenseCountObj[licenseObj.license] = licenseObj.count;
-    });
-
-    return treeify.asTree(sortedLicenseCountObj, true);
-};
-
-exports.asCSV = function(sorted, customFormat, csvComponentPrefix) {
-    var text = [], textArr = [], lineArr = [];
-    var prefixName = '"component"';
-    var prefix = csvComponentPrefix;
-
-    if (customFormat && Object.keys(customFormat).length > 0) {
-        textArr = [];
-        if (csvComponentPrefix) { textArr.push(prefixName); }
-        textArr.push('"module name"');
-        Object.keys(customFormat).forEach(function forEachCallback(item) {
-            textArr.push('"' + item + '"');
-        });
-        text.push(textArr.join(','));
-    } else {
-        textArr = [];
-        /*istanbul ignore next*/
-        if (csvComponentPrefix) { textArr.push(prefixName); }
-        ['"module name"','"license"','"repository"'].forEach(function(item) {
-            textArr.push(item);
-        });
-        text.push(textArr.join(','));
+    if (err) {
+      debugError(err);
+      inputError = err;
     }
 
-    Object.keys(sorted).forEach(function(key) {
-        var module = sorted[key],
-            line = '';
-        lineArr = [];
+    //Return the callback and variables nicely
+    callback(inputError, restricted);
+  });
+};
 
-        //Grab the custom keys from the custom format
-        if (customFormat && Object.keys(customFormat).length > 0) {
-            if (csvComponentPrefix) {
-                lineArr.push('"'+prefix+'"');
-            }
-            lineArr.push('"' + key + '"');
-            Object.keys(customFormat).forEach(function forEachCallback(item) {
-                lineArr.push('"' + module[item] + '"');
-            });
-            line = lineArr.join(',');
-        } else {
-            /*istanbul ignore next*/
-            if (csvComponentPrefix) {
-                lineArr.push('"'+prefix+'"');
-            }
-            lineArr.push([
-                '"' + key + '"',
-                '"' + (module.licenses || '') + '"',
-                '"' + (module.repository || '') + '"'
-            ]);
-            line = lineArr.join(',');
-        }
-        text.push(line);
+exports.print = function (sorted) {
+  console.log(exports.asTree(sorted));
+};
+
+exports.asTree = function (sorted) {
+  return treeify.asTree(sorted, true);
+};
+
+exports.asSummary = function (sorted) {
+  var licenseCountObj = {};
+  var licenceCountArray = [];
+  var sortedLicenseCountObj = {};
+
+  Object.keys(sorted).forEach(function (key) {
+    /*istanbul ignore else*/
+    if (sorted[key].licenses) {
+      licenseCountObj[sorted[key].licenses] =
+        licenseCountObj[sorted[key].licenses] || 0;
+      licenseCountObj[sorted[key].licenses]++;
+    }
+  });
+
+  Object.keys(licenseCountObj).forEach(function (license) {
+    licenceCountArray.push({
+      license: license,
+      count: licenseCountObj[license],
     });
+  });
 
-    return text.join('\n');
+  /*istanbul ignore next*/
+  licenceCountArray.sort(function (a, b) {
+    return b["count"] - a["count"];
+  });
+
+  licenceCountArray.forEach(function (licenseObj) {
+    sortedLicenseCountObj[licenseObj.license] = licenseObj.count;
+  });
+
+  return treeify.asTree(sortedLicenseCountObj, true);
+};
+
+exports.asCSV = function (sorted, customFormat, csvComponentPrefix) {
+  var text = [],
+    textArr = [],
+    lineArr = [];
+  var prefixName = '"component"';
+  var prefix = csvComponentPrefix;
+
+  if (customFormat && Object.keys(customFormat).length > 0) {
+    textArr = [];
+    if (csvComponentPrefix) {
+      textArr.push(prefixName);
+    }
+    textArr.push('"module name"');
+    Object.keys(customFormat).forEach(function forEachCallback(item) {
+      textArr.push('"' + item + '"');
+    });
+    text.push(textArr.join(","));
+  } else {
+    textArr = [];
+    /*istanbul ignore next*/
+    if (csvComponentPrefix) {
+      textArr.push(prefixName);
+    }
+    ['"module name"', '"license"', '"repository"'].forEach(function (item) {
+      textArr.push(item);
+    });
+    text.push(textArr.join(","));
+  }
+
+  Object.keys(sorted).forEach(function (key) {
+    var module = sorted[key],
+      line = "";
+    lineArr = [];
+
+    //Grab the custom keys from the custom format
+    if (customFormat && Object.keys(customFormat).length > 0) {
+      if (csvComponentPrefix) {
+        lineArr.push('"' + prefix + '"');
+      }
+      lineArr.push('"' + key + '"');
+      Object.keys(customFormat).forEach(function forEachCallback(item) {
+        lineArr.push('"' + module[item] + '"');
+      });
+      line = lineArr.join(",");
+    } else {
+      /*istanbul ignore next*/
+      if (csvComponentPrefix) {
+        lineArr.push('"' + prefix + '"');
+      }
+      lineArr.push([
+        '"' + key + '"',
+        '"' + (module.licenses || "") + '"',
+        '"' + (module.repository || "") + '"',
+      ]);
+      line = lineArr.join(",");
+    }
+    text.push(line);
+  });
+
+  return text.join("\n");
 };
 
 /**
-* Exports data as markdown (*.md) file which has it's own syntax.
-* @method
-* @param  {JSON} sorted       The sorted JSON data from all packages.
-* @param  {JSON} customFormat The custom format with information about the needed keys.
-* @return {String}            The returning plain text.
-*/
-exports.asMarkDown = function(sorted, customFormat) {
-
-    var text = [];
-    if (customFormat && Object.keys(customFormat).length > 0) {
-        Object.keys(sorted).forEach(function sortedCallback(sortedItem) {
-            text.push(' - **[' + sortedItem + '](' + sorted[sortedItem].repository + ')**');
-            Object.keys(customFormat).forEach(function customCallback(customItem) {
-                text.push('    - ' +  customItem + ': ' + sorted[sortedItem][customItem]);
-            });
-        });
-        text = text.join('\n');
-    } else {
-        Object.keys(sorted).forEach(function(key) {
-            var module = sorted[key];
-            text.push('[' + key + '](' + module.repository + ') - ' + module.licenses);
-        });
-        text = text.join('\n');
-    }
-
-    return text;
-};
-
-exports.parseJson = function(jsonPath) {
-    if (typeof jsonPath !== 'string') {
-        return new Error('did not specify a path');
-    }
-
-    var jsonFileContents = '',
-        result = { };
-
-    try {
-        jsonFileContents = fs.readFileSync(jsonPath, { encoding: 'utf8' });
-        result = JSON.parse(jsonFileContents);
-    } catch (err) {
-        result = err;
-    }
-    return result;
-};
-
-exports.asFiles = function(json, outDir) {
-    mkdirp.sync(outDir);
-    Object.keys(json).forEach(function(moduleName) {
-        var licenseFile = json[moduleName].licenseFile,
-            fileContents, outFileName, outPath, baseDir;
-
-        if (licenseFile && fs.existsSync(licenseFile)) {
-            fileContents = fs.readFileSync(licenseFile);
-            outFileName = moduleName + "-LICENSE.txt";
-            outPath = path.join(outDir, outFileName);
-            baseDir = path.dirname(outPath);
-            mkdirp.sync(baseDir);
-            fs.writeFileSync(outPath, fileContents, "utf8");
-        } else {
-            console.warn("no license file found for: " + moduleName);
-        }
+ * Exports data as markdown (*.md) file which has it's own syntax.
+ * @method
+ * @param  {JSON} sorted       The sorted JSON data from all packages.
+ * @param  {JSON} customFormat The custom format with information about the needed keys.
+ * @return {String}            The returning plain text.
+ */
+exports.asMarkDown = function (sorted, customFormat) {
+  var text = [];
+  if (customFormat && Object.keys(customFormat).length > 0) {
+    Object.keys(sorted).forEach(function sortedCallback(sortedItem) {
+      text.push(
+        " - **[" + sortedItem + "](" + sorted[sortedItem].repository + ")**"
+      );
+      Object.keys(customFormat).forEach(function customCallback(customItem) {
+        text.push(
+          "    - " + customItem + ": " + sorted[sortedItem][customItem]
+        );
+      });
     });
+    text = text.join("\n");
+  } else {
+    Object.keys(sorted).forEach(function (key) {
+      var module = sorted[key];
+      text.push(
+        "[" + key + "](" + module.repository + ") - " + module.licenses
+      );
+    });
+    text = text.join("\n");
+  }
+
+  return text;
+};
+
+exports.parseJson = function (jsonPath) {
+  if (typeof jsonPath !== "string") {
+    return new Error("did not specify a path");
+  }
+
+  var jsonFileContents = "",
+    result = {};
+
+  try {
+    jsonFileContents = fs.readFileSync(jsonPath, { encoding: "utf8" });
+    result = JSON.parse(jsonFileContents);
+  } catch (err) {
+    result = err;
+  }
+  return result;
+};
+
+exports.asFiles = function (json, outDir) {
+  mkdirp.sync(outDir);
+  Object.keys(json).forEach(function (moduleName) {
+    var licenseFile = json[moduleName].licenseFile,
+      fileContents,
+      outFileName,
+      outPath,
+      baseDir;
+
+    if (licenseFile && fs.existsSync(licenseFile)) {
+      fileContents = fs.readFileSync(licenseFile);
+      outFileName = moduleName + "-LICENSE.txt";
+      outPath = path.join(outDir, outFileName);
+      baseDir = path.dirname(outPath);
+      mkdirp.sync(baseDir);
+      fs.writeFileSync(outPath, fileContents, "utf8");
+    } else {
+      console.warn("no license file found for: " + moduleName);
+    }
+  });
 };

--- a/tests/failOn-test.js
+++ b/tests/failOn-test.js
@@ -1,73 +1,73 @@
 var assert = require("assert"),
-  path = require("path"),
-  spawn = require("child_process").spawn;
+    path = require("path"),
+    spawn = require("child_process").spawn;
 
-describe("bin/license-checker", function () {
-  this.timeout(8000);
-  it("should exit 1 if it finds a single license type (MIT) license due to --failOn MIT", function (done) {
-    spawn(
-      "node",
-      [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT"],
-      {
-        cwd: path.join(__dirname, "../"),
-        stdio: "ignore",
-      }
-    ).on("exit", function (code) {
-      assert.equal(code, 1);
-      done();
+describe("bin/license-checker", function() {
+    this.timeout(8000);
+    it("should exit 1 if it finds a single license type (MIT) license due to --failOn MIT", function(done) {
+        spawn(
+            "node",
+            [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT"],
+            {
+                cwd: path.join(__dirname, "../"),
+                stdio: "ignore",
+            }
+        ).on("exit", function(code) {
+            assert.equal(code, 1);
+            done();
+        });
     });
-  });
 
-  it("should exit 1 if it finds any license type that matches the regex (MI*) license due to --failOnRegEx MI*", function (done) {
-    spawn(
-      "node",
-      [path.join(__dirname, "../bin/license-checker"), "--failOnRegEx", "MI*"],
-      {
-        cwd: path.join(__dirname, "../"),
-        stdio: "ignore",
-      }
-    ).on("exit", function (code) {
-      assert.equal(code, 1);
-      done();
+    it("should exit 1 if it finds any license type that matches the regex (MI*) license due to --failOnRegEx MI*", function(done) {
+        spawn(
+            "node",
+            [path.join(__dirname, "../bin/license-checker"), "--failOnRegEx", "MI*"],
+            {
+                cwd: path.join(__dirname, "../"),
+                stdio: "ignore",
+            }
+        ).on("exit", function(code) {
+            assert.equal(code, 1);
+            done();
+        });
     });
-  });
 
-  it("should exit 1 if it finds forbidden licenses license due to --failOn MIT;ISC", function (done) {
-    spawn(
-      "node",
-      [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT;ISC"],
-      {
-        cwd: path.join(__dirname, "../"),
-        stdio: "ignore",
-      }
-    ).on("exit", function (code) {
-      assert.equal(code, 1);
-      done();
+    it("should exit 1 if it finds forbidden licenses license due to --failOn MIT;ISC", function(done) {
+        spawn(
+            "node",
+            [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT;ISC"],
+            {
+                cwd: path.join(__dirname, "../"),
+                stdio: "ignore",
+            }
+        ).on("exit", function(code) {
+            assert.equal(code, 1);
+            done();
+        });
     });
-  });
 
-  it("should give warning about commas if --failOn MIT,ISC is provided", function (done) {
-    var proc = spawn(
-      "node",
-      [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT,ISC"],
-      {
-        cwd: path.join(__dirname, "../"),
-        stdio: "pipe",
-      }
-    );
-    var stderr = "";
-    proc.stdout.on("data", function () {});
-    proc.stderr.on("data", function (data) {
-      stderr += data.toString();
+    it("should give warning about commas if --failOn MIT,ISC is provided", function(done) {
+        var proc = spawn(
+            "node",
+            [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT,ISC"],
+            {
+                cwd: path.join(__dirname, "../"),
+                stdio: "pipe",
+            }
+        );
+        var stderr = "";
+        proc.stdout.on("data", function() {});
+        proc.stderr.on("data", function(data) {
+            stderr += data.toString();
+        });
+        proc.on("close", function() {
+            assert.equal(
+                stderr.indexOf(
+                    "--failOn argument takes semicolons as delimeters instead of commas"
+                ) >= 0,
+                true
+            );
+            done();
+        });
     });
-    proc.on("close", function () {
-      assert.equal(
-        stderr.indexOf(
-          "--failOn argument takes semicolons as delimeters instead of commas"
-        ) >= 0,
-        true
-      );
-      done();
-    });
-  });
 });

--- a/tests/failOn-test.js
+++ b/tests/failOn-test.js
@@ -1,42 +1,73 @@
-var assert = require('assert'),
-    path = require('path'),
-    spawn = require('child_process').spawn;
+var assert = require("assert"),
+  path = require("path"),
+  spawn = require("child_process").spawn;
 
-describe('bin/license-checker', function() {
-    this.timeout(8000);
-    it('should exit 1 if it finds a single license type (MIT) license due to --failOn MIT', function(done) {
-        spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT'], {
-            cwd: path.join(__dirname, '../'),
-            stdio: 'ignore'
-        }).on('exit', function(code) {
-            assert.equal(code, 1);
-            done();
-        });
+describe("bin/license-checker", function () {
+  this.timeout(8000);
+  it("should exit 1 if it finds a single license type (MIT) license due to --failOn MIT", function (done) {
+    spawn(
+      "node",
+      [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT"],
+      {
+        cwd: path.join(__dirname, "../"),
+        stdio: "ignore",
+      }
+    ).on("exit", function (code) {
+      assert.equal(code, 1);
+      done();
     });
+  });
 
-    it('should exit 1 if it finds forbidden licenses license due to --failOn MIT;ISC', function(done) {
-        spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT;ISC'], {
-            cwd: path.join(__dirname, '../'),
-            stdio: 'ignore'
-        }).on('exit', function(code) {
-            assert.equal(code, 1);
-            done();
-        });
+  it("should exit 1 if it finds any license type that matches the regex (MI*) license due to --failOnRegEx MI*", function (done) {
+    spawn(
+      "node",
+      [path.join(__dirname, "../bin/license-checker"), "--failOnRegEx", "MI*"],
+      {
+        cwd: path.join(__dirname, "../"),
+        stdio: "ignore",
+      }
+    ).on("exit", function (code) {
+      assert.equal(code, 1);
+      done();
     });
+  });
 
-    it('should give warning about commas if --failOn MIT,ISC is provided', function(done) {
-        var proc = spawn('node', [path.join(__dirname, '../bin/license-checker'), '--failOn', 'MIT,ISC'], {
-            cwd: path.join(__dirname, '../'),
-            stdio: 'pipe'
-        });
-        var stderr = '';
-        proc.stdout.on('data', function() { });
-        proc.stderr.on('data', function(data) {
-            stderr += data.toString();
-        });
-        proc.on('close', function() {
-            assert.equal(stderr.indexOf('--failOn argument takes semicolons as delimeters instead of commas') >= 0, true);
-            done();
-        });
+  it("should exit 1 if it finds forbidden licenses license due to --failOn MIT;ISC", function (done) {
+    spawn(
+      "node",
+      [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT;ISC"],
+      {
+        cwd: path.join(__dirname, "../"),
+        stdio: "ignore",
+      }
+    ).on("exit", function (code) {
+      assert.equal(code, 1);
+      done();
     });
+  });
+
+  it("should give warning about commas if --failOn MIT,ISC is provided", function (done) {
+    var proc = spawn(
+      "node",
+      [path.join(__dirname, "../bin/license-checker"), "--failOn", "MIT,ISC"],
+      {
+        cwd: path.join(__dirname, "../"),
+        stdio: "pipe",
+      }
+    );
+    var stderr = "";
+    proc.stdout.on("data", function () {});
+    proc.stderr.on("data", function (data) {
+      stderr += data.toString();
+    });
+    proc.on("close", function () {
+      assert.equal(
+        stderr.indexOf(
+          "--failOn argument takes semicolons as delimeters instead of commas"
+        ) >= 0,
+        true
+      );
+      done();
+    });
+  });
 });


### PR DESCRIPTION
It would be helpful for organizations to be able to fail a license-check via regex expression. For example, there are [many GPL](https://spdx.org/licenses/) licenses and an organization may want to fail if any variety is encountered. An additional option that does not interfere with the current --failOn would be ideal for handling these cases. 