### PR TITLE
Added LICENSE.md to the list of license file regexes

### DIFF
--- a/lib/license-files.js
+++ b/lib/license-files.js
@@ -4,6 +4,7 @@ var BASENAMES_PRECEDENCE = [
     /^LICENSE$/,
     /^LICENSE\-\w+$/, // e.g. LICENSE-MIT
     /^LICENCE$/,
+    /^LICENCE\.md$/,
     /^LICENCE\-\w+$/, // e.g. LICENCE-MIT
     /^COPYING$/,
     /^README$/,


### PR DESCRIPTION
Some projects like [graphql-editor/graphql-zeus](https://github.com/graphql-editor/graphql-zeus/blob/master/LICENSE.md) put their license in LICENSE.md. If they do this their license currently comes up as unknown. I just added LICENSE.md to the regexes to fix this.